### PR TITLE
Fix move ordering scores

### DIFF
--- a/src/History.cpp
+++ b/src/History.cpp
@@ -6,7 +6,7 @@ void updateHH(S_Board* pos, int depth, int bestmove, S_MOVELIST* quiet_moves) {
 	if (depth > 1)
 		//if we are at a depth >1 increment the history score of the best move
 		pos->searchHistory[pos->pieces[get_move_source(bestmove)]]
-		[get_move_target(bestmove)] += 1 << depth;
+		[get_move_target(bestmove)] += depth*depth*depth;
 	//Loop through all the quiet moves
 	for (int i = 0; i < quiet_moves->count; i++) {
 		int move = quiet_moves->moves[i].move;
@@ -14,7 +14,7 @@ void updateHH(S_Board* pos, int depth, int bestmove, S_MOVELIST* quiet_moves) {
 			continue;
 		else { // if the move isn't the best move decrease its history score
 			pos->searchHistory[pos->pieces[get_move_source(move)]]
-				[get_move_target(move)] -= 1 << depth;
+				[get_move_target(move)] -= depth*depth*depth;
 		}
 	}
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -214,7 +214,7 @@ static inline void score_moves(S_Board* pos, S_MOVELIST* move_list,
 		//if the move isn't in any of the previous categories score it according to the history heuristic
 		else {
 
-			move_list->moves[i].score = (std::min)(599000000, pos->searchHistory[pos->pieces[get_move_source(move)]][get_move_target(move)]);
+			move_list->moves[i].score = (std::min)(499000000, pos->searchHistory[pos->pieces[get_move_source(move)]][get_move_target(move)]);
 			continue;
 		}
 	}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -176,13 +176,13 @@ static inline void score_moves(S_Board* pos, S_MOVELIST* move_list,
 			continue;
 		}
 		else if (get_move_promoted(move)) {
-			move_list->moves[i].score = 100000000 + get_move_promoted(move);
+			move_list->moves[i].score = 2000000000 + get_move_promoted(move);
 			continue;
 		}
 		//if the move is an enpassant or a promotion give it a score that a good capture of type pawn-pwan would have
 		else if (get_move_enpassant(move)) {
 
-			move_list->moves[i].score = 105 + 90000000;
+			move_list->moves[i].score = 105 + 1000000000;
 			continue;
 		}
 		//if the mvoe is a capture sum the mvv-lva score to a variable that depends on whether the capture has a positive SEE or not 
@@ -190,31 +190,31 @@ static inline void score_moves(S_Board* pos, S_MOVELIST* move_list,
 
 			move_list->moves[i].score =
 				mvv_lva[get_move_piece(move)][pos->pieces[get_move_target(move)]] +
-				50000000 + 40000000 * SEE(pos, move, -100);
+				500000000 + 400000000 * SEE(pos, move, -100);
 			continue;
 		}
 		//First  killer move always comes after the TT move,the promotions and the good captures and before anything else
 		else if (pos->searchKillers[0][pos->ply] == move) {
 
-			move_list->moves[i].score = 80000000;
+			move_list->moves[i].score = 800000000;
 			continue;
 		}
 		//Second killer move always comes after the first one
 		else if (pos->searchKillers[1][pos->ply] == move) {
 
-			move_list->moves[i].score = 70000000;
+			move_list->moves[i].score = 700000000;
 			continue;
 		}
 		//After the killer moves try the Counter moves
 		else if (move == CounterMoves[get_move_source(pos->history[pos->hisPly].move)][get_move_target(pos->history[pos->hisPly].move)])
 		{
-			move_list->moves[i].score = 60000000;
+			move_list->moves[i].score = 600000000;
 			continue;
 		}
 		//if the move isn't in any of the previous categories score it according to the history heuristic
 		else {
 
-			move_list->moves[i].score = pos->searchHistory[pos->pieces[get_move_source(move)]][get_move_target(move)];
+			move_list->moves[i].score = (std::min)(500000000, pos->searchHistory[pos->pieces[get_move_source(move)]][get_move_target(move)]);
 			continue;
 		}
 	}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -214,7 +214,7 @@ static inline void score_moves(S_Board* pos, S_MOVELIST* move_list,
 		//if the move isn't in any of the previous categories score it according to the history heuristic
 		else {
 
-			move_list->moves[i].score = (std::min)(499000000, pos->searchHistory[pos->pieces[get_move_source(move)]][get_move_target(move)]);
+			move_list->moves[i].score =  pos->searchHistory[pos->pieces[get_move_source(move)]][get_move_target(move)];
 			continue;
 		}
 	}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -214,7 +214,7 @@ static inline void score_moves(S_Board* pos, S_MOVELIST* move_list,
 		//if the move isn't in any of the previous categories score it according to the history heuristic
 		else {
 
-			move_list->moves[i].score = (std::min)(500000000, pos->searchHistory[pos->pieces[get_move_source(move)]][get_move_target(move)]);
+			move_list->moves[i].score = (std::min)(599000000, pos->searchHistory[pos->pieces[get_move_source(move)]][get_move_target(move)]);
 			continue;
 		}
 	}


### PR DESCRIPTION
STC 10.0+0.1
ELO   | 8.48 +- 5.48 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7048 W: 1700 L: 1528 D: 3820

LTC 40/720
Score of Alexandria2.3.2 vs Alexandria-2.3.1: 12 - 4 - 35 [0.578]
...      Alexandria2.3.2 playing White: 8 - 0 - 18  [0.654] 26
...      Alexandria2.3.2 playing Black: 4 - 4 - 17  [0.500] 25
...      White vs Black: 12 - 4 - 35  [0.578] 51
Elo difference: 55.0 +/- 52.9, LOS: 97.7 %, DrawRatio: 68.6 %
51 of 10000 games finished.

More tests are needed at ltc but it appears to be a positive change and to scale with time control length 