### PR TITLE
Skip bad captures in QSearch based on SEE score

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -334,6 +334,13 @@ int Quiescence(int alpha, int beta, S_Board* pos, S_SearchINFO* info) {
 
 		pick_move(move_list, count);
 		int move = move_list->moves[count].move;
+		int move_Score = move_list->moves[count].score;
+		if (moves_searched > 0
+			&& BestScore > -ISMATE
+			&& get_move_capture(move)
+			&& move_Score == 500000000)
+			continue;
+
 		make_move(move, pos);
 		// increment nodes count
 		info->nodes++;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -338,7 +338,7 @@ int Quiescence(int alpha, int beta, S_Board* pos, S_SearchINFO* info) {
 		if (moves_searched > 0
 			&& BestScore > -ISMATE
 			&& get_move_capture(move)
-			&& move_Score == 500000000)
+			&& move_Score < 600000000)
 			continue;
 
 		make_move(move, pos);


### PR DESCRIPTION
ELO   | 16.44 +- 7.43 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2856 W: 554 L: 419 D: 1883