### PR TITLE
Prevent dropping into Qsearch if in check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -363,7 +363,7 @@ int negamax(int alpha, int beta, int depth, S_Board* pos, S_Stack* ss, S_SearchI
 
 	ss->pvLength[pos->ply] = pos->ply;
 
-	if (in_check) depth++;
+	if (in_check) depth = (std::max)(1, depth + 1);
 
 	//Check for the highest depth reached in search to report it to the cli
 	if (pos->ply > info->seldepth)


### PR DESCRIPTION
Bench: 5299844

ELO   | 5.36 +- 4.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13496 W: 3410 L: 3202 D: 6884