### PR TITLE
Increase threads limit to 256

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -347,7 +347,7 @@ void Uci_Loop(char** argv) {
 			printf("id name Alexandria 4.0\n");
 			printf("id author PGG\n");
 			printf("option name Hash type spin default 16 min 1 max 8192 \n");
-			printf("option name Threads type spin default 1 min 1 max 4 \n");
+			printf("option name Threads type spin default 1 min 1 max 256 \n");
 			printf("option name MultiPV type spin default 1 min 1 max 1\n");
 			printf("uciok\n");
 		}


### PR DESCRIPTION
Bench: 5398962

The engine was tested up to 16 threads thanks to Plutie from the OB discord, this is realistically the most threads i'll manage to get it tested with.
```Score of alexandria-16t vs alexandria-4t: 937 - 275 - 490  [0.694] 1702
...      alexandria-16t playing White: 607 - 58 - 186  [0.823] 851
...      alexandria-16t playing Black: 330 - 217 - 304  [0.566] 851
...      White vs Black: 824 - 388 - 490  [0.628] 1702
Elo difference: 142.6 +/- 14.6, LOS: 100.0 %, DrawRatio: 28.8 %
```

I also ran an STC regression test against 3.1.0 because i fear it might have regressed and i'm glad to say it did not
```ELO   | 20.21 +- 5.11 (95%)
CONF  | 10.0+0.10s Threads=1 Hash=8MB
GAMES | N: 7968 W: 2025 L: 1562 D: 4381
```