### PR TITLE
Reduce big time spikes by reducing PV re-searches above original depth.

### DIFF
--- a/src/datagen.cpp
+++ b/src/datagen.cpp
@@ -82,8 +82,8 @@ int sanity_search(S_ThreadData* td)
 	// define initial alpha beta bounds
 	int alpha = -MAXSCORE;
 	int beta = MAXSCORE;
-	score = Negamax(alpha, beta, 10, td, ss);
-
+	score = Negamax(alpha, beta, 10 ,10, td, ss);
+	
 	return score;
 }
 
@@ -103,8 +103,8 @@ int search_best_move(S_ThreadData* td)
 	// Call the Negamax function in an iterative deepening framework
 	for (int current_depth = 1; current_depth <= info->depth; current_depth++)
 	{
-		score = Negamax(alpha, beta, current_depth, td, ss);
-
+		score = Negamax(alpha, beta, current_depth, current_depth, td, ss);
+		
 		// check if we just cleared a depth and we used the nodes we had we stop
 		if (NodesOver(&td->info))
 			info->stopped = true;

--- a/src/search.h
+++ b/src/search.h
@@ -34,7 +34,7 @@ void SearchPosition(int start_depth, int final_depth, S_ThreadData* td, S_UciOpt
 //Sets up aspiration windows and starts a Negamax search
 int AspirationWindowSearch(int prev_eval, int depth, S_ThreadData* td);
 // Negamax alpha beta search
-int Negamax(int alpha, int beta, int depth, S_ThreadData* td, Search_stack* ss);
+int Negamax(int alpha, int beta, int depth, int maxNextDepth, S_ThreadData* td, Search_stack* ss);
 //Quiescence search to avoid the horizon effect
 int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss);
 


### PR DESCRIPTION
Save time by reducing PV re-searches above original depth. Instead use 5% extra time on every move.

STC 10+0.1 th 1 :
LLR: 2.93 (-2.94,2.94) {-0.25,1.25}
Total: 90688 W: 9702 L: 9436 D: 71550
Ptnml(0-2): 408, 7252, 29792, 7450, 442

LTC 60+0.6 th 1 :
LLR: 2.97 (-2.94,2.94) {0.25,1.25}
Total: 97856 W: 4602 L: 4303 D: 88951
Ptnml(0-2): 53, 3757, 41057, 3960, 101