### PR TITLE
Decrease the LMR reduction for moves that have a good history score

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -578,6 +578,7 @@ moves_loop:
 			//calculate by how much we should reduce the search depth 
 			depth_reduction = reduction(pv_node, improving, depth, moves_searched);
 			int movehistory = GetHistoryScore(pos, sd, move, ss);
+			//Decrease the reduction for moves that have a good history score
 			if (movehistory > 16384) depth_reduction--;
 			//adjust the reduction so that we can't drop into Qsearch and to prevent extensions
 			depth_reduction = std::min(depth - 1, std::max(depth_reduction, 1));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -577,6 +577,8 @@ moves_loop:
 		{
 			//calculate by how much we should reduce the search depth 
 			depth_reduction = reduction(pv_node, improving, depth, moves_searched);
+			int movehistory = GetHistoryScore(pos, sd, move, ss);
+			if (movehistory > 16384) depth_reduction--;
 			//adjust the reduction so that we can't drop into Qsearch and to prevent extensions
 			depth_reduction = std::min(depth - 1, std::max(depth_reduction, 1));
 			// search current move with reduced depth:


### PR DESCRIPTION
ELO   | 4.97 +- 3.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 20832 W: 5493 L: 5195 D: 10144

Bench: 2743847