### PR TITLE
Extend LMR to also cover tactical moves 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -602,14 +602,15 @@ moves_loop:
 		// conditions to consider LMR
 		if (moves_searched >= 3 + 2 * pv_node
 			&& depth >= 3
-			&& !in_check
-			&& isQuiet)
+			&& !in_check)
 		{
 			//calculate by how much we should reduce the search depth 
 			depth_reduction = reduction(pv_node, improving, depth, moves_searched);
-			int movehistory = GetHistoryScore(pos, sd, move, ss);
-			//Decrease the reduction for moves that have a good history score
-			if (movehistory > 16384) depth_reduction--;
+			if (isQuiet) {
+				int movehistory = GetHistoryScore(pos, sd, move, ss);
+				//Decrease the reduction for moves that have a good history score
+				if (movehistory > 16384) depth_reduction--;
+			}
 			//adjust the reduction so that we can't drop into Qsearch and to prevent extensions
 			depth_reduction = std::min(depth - 1, std::max(depth_reduction, 1));
 			// search current move with reduced depth:

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -604,12 +604,16 @@ moves_loop:
 			&& depth >= 3
 			&& !in_check)
 		{
-			//calculate by how much we should reduce the search depth 
-			depth_reduction = reduction(pv_node, improving, depth, moves_searched);
 			if (isQuiet) {
+				//calculate by how much we should reduce the search depth 
+				depth_reduction = reduction(pv_node, improving, depth, moves_searched);
 				int movehistory = GetHistoryScore(pos, sd, move, ss);
 				//Decrease the reduction for moves that have a good history score
 				if (movehistory > 16384) depth_reduction--;
+			}
+			else {
+				//calculate by how much we should reduce the search depth 
+				depth_reduction = reduction(pv_node, improving, depth, moves_searched);
 			}
 			//adjust the reduction so that we can't drop into Qsearch and to prevent extensions
 			depth_reduction = std::min(depth - 1, std::max(depth_reduction, 1));


### PR DESCRIPTION
ELO   | 6.21 +- 3.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 15544 W: 3993 L: 3715 D: 7836

ELO   | 7.67 +- 4.33 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 12008 W: 3058 L: 2793 D: 6157