### PR TITLE
Use total moves played instead of just quiet moves for the lmp margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -541,7 +541,7 @@ moves_loop:
 				&& !in_check
 				&& depth < 4
 				&& isQuiet
-				&& quiet_moves.count > lmp_margin[depth][improving])
+				&& moves_searched > lmp_margin[depth][improving])
 			{
 				SkipQuiets = true;
 				continue;


### PR DESCRIPTION
ELO   | 3.18 +- 2.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 38112 W: 9591 L: 9242 D: 19279

Bench: 2839773