### PR TITLE
Scale time used for a search based on the percent of nodes spent searching the best move

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -113,6 +113,8 @@ struct S_SearchINFO {
 	//search start time 
 	uint64_t starttime = 0;
 	//search time initial lower bound if present
+	uint64_t stoptimeOptBase = 0;
+	//search time scaled lower bound if present
 	uint64_t stoptimeOpt = 0;
 	//search time upper bound if present
 	uint64_t stoptimeMax = 0;

--- a/src/board.h
+++ b/src/board.h
@@ -113,7 +113,7 @@ struct S_SearchINFO {
 	//search start time 
 	uint64_t starttime = 0;
 	//search time initial lower bound if present
-	uint64_t stoptimeOptBase = 0;
+	uint64_t stoptimeBaseOpt = 0;
 	//search time scaled lower bound if present
 	uint64_t stoptimeOpt = 0;
 	//search time upper bound if present

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -653,8 +653,9 @@ moves_loop:
 
 		// take move back
 		Unmake_move(move, pos);
-
-		td->nodeSpentTable[From(move)][To(move)] += info->nodes - nodes_before_search;
+		if (td->id == 0
+			&& root_node)
+			td->nodeSpentTable[From(move)][To(move)] += info->nodes - nodes_before_search;
 
 		if (info->stopped)
 			return 0;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -277,7 +277,7 @@ void SearchPosition(int start_depth, int final_depth, S_ThreadData* td, S_UciOpt
 				double bestMoveNodesFraction = static_cast<double>(td->nodeSpentTable[From(bestmove)][To(bestmove)]) / static_cast<double>(td->info.nodes);
 				double nodeScalingFactor = (1.5 - bestMoveNodesFraction) * 1.35;
 				//Scale the search time based on how many nodes we spent
-				td->info.stoptimeOpt = std::min<uint64_t>(td->info.starttime + td->info.stoptimeOptBase * nodeScalingFactor, td->info.stoptimeMax);
+				td->info.stoptimeOpt = std::min<uint64_t>(td->info.starttime + td->info.stoptimeBaseOpt * nodeScalingFactor, td->info.stoptimeMax);
 			}
 
 			// check if we just cleared a depth and more than OptTime passed, or we used more than the give nodes

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -272,7 +272,7 @@ void SearchPosition(int start_depth, int final_depth, S_ThreadData* td, S_UciOpt
 		if (td->id == 0) {
 			// use the previous search to adjust some of the time management parameters
 			if (td->RootDepth > 7) {
-				int bestmove = td->pv_table.pvArray[0][0];
+				int bestmove = GetBestMove(&td->pv_table);
 				// Calculate how many nodes were spent on checking the best move
 				double bestMoveNodesFraction = static_cast<double>(td->nodeSpentTable[From(bestmove)][To(bestmove)]) / static_cast<double>(td->info.nodes);
 				double nodeScalingFactor = (1.5 - bestMoveNodesFraction) * 1.35;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -283,9 +283,9 @@ void SearchPosition(int start_depth, int final_depth, S_ThreadData* td, S_UciOpt
 				int bestmove = td->pv_table.pvArray[0][0];
 				// Calculate how many nodes were spent on checking the best move
 				auto bestMoveNodesFraction = 1.0 * td->nodeSpentTable[From(bestmove)][To(bestmove)] / td->info.nodes;
-				auto nodeScalingFactor = 1.25 - bestMoveNodesFraction;
+				auto nodeScalingFactor = 1.5 - bestMoveNodesFraction;
 				//Scale the search time based on how many nodes we spent
-				td->info.stoptimeOpt = td->info.starttime + td->info.stoptimeOptBase * nodeScalingFactor;
+				td->info.stoptimeOpt = std::min<uint64_t>(td->info.starttime + td->info.stoptimeOptBase * nodeScalingFactor, td->info.stoptimeMax);
 			}
 		}
 		// stop calculating and return best move so far

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -283,8 +283,8 @@ void SearchPosition(int start_depth, int final_depth, S_ThreadData* td, S_UciOpt
 				if (td->RootDepth > 7) {
 					int bestmove = td->pv_table.pvArray[0][0];
 					// Calculate how many nodes were spent on checking the best move
-					auto bestMoveNodesFraction = 1.0 * td->nodeSpentTable[From(bestmove)][To(bestmove)] / td->info.nodes;
-					auto nodeScalingFactor = 1.5 - bestMoveNodesFraction;
+					double bestMoveNodesFraction = static_cast<double>(td->nodeSpentTable[From(bestmove)][To(bestmove)]) / static_cast<double>(td->info.nodes);
+					double nodeScalingFactor = 1.5 - bestMoveNodesFraction;
 					//Scale the search time based on how many nodes we spent
 					td->info.stoptimeOpt = std::min<uint64_t>(td->info.starttime + td->info.stoptimeOptBase * nodeScalingFactor, td->info.stoptimeMax);
 				}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -283,8 +283,9 @@ void SearchPosition(int start_depth, int final_depth, S_ThreadData* td, S_UciOpt
 				int bestmove = td->pv_table.pvArray[0][0];
 				// Calculate how many nodes were spent on checking the best move
 				auto bestMoveNodesFraction = 1.0 * td->nodeSpentTable[From(bestmove)][To(bestmove)] / td->info.nodes;
+				auto nodeScalingFactor = 1.25 - bestMoveNodesFraction;
 				//Scale the search time based on how many nodes we spent
-				td->info.stoptimeOpt = td->info.starttime + td->info.stoptimeOptBase * bestMoveNodesFraction;
+				td->info.stoptimeOpt = td->info.starttime + td->info.stoptimeOptBase * nodeScalingFactor;
 			}
 		}
 		// stop calculating and return best move so far

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -280,12 +280,14 @@ void SearchPosition(int start_depth, int final_depth, S_ThreadData* td, S_UciOpt
 			}
 			// if we don't have to stop use the previous search to adjust some of the time management parameters
 			else {
-				int bestmove = td->pv_table.pvArray[0][0];
-				// Calculate how many nodes were spent on checking the best move
-				auto bestMoveNodesFraction = 1.0 * td->nodeSpentTable[From(bestmove)][To(bestmove)] / td->info.nodes;
-				auto nodeScalingFactor = 1.5 - bestMoveNodesFraction;
-				//Scale the search time based on how many nodes we spent
-				td->info.stoptimeOpt = std::min<uint64_t>(td->info.starttime + td->info.stoptimeOptBase * nodeScalingFactor, td->info.stoptimeMax);
+				if (td->RootDepth > 7) {
+					int bestmove = td->pv_table.pvArray[0][0];
+					// Calculate how many nodes were spent on checking the best move
+					auto bestMoveNodesFraction = 1.0 * td->nodeSpentTable[From(bestmove)][To(bestmove)] / td->info.nodes;
+					auto nodeScalingFactor = 1.5 - bestMoveNodesFraction;
+					//Scale the search time based on how many nodes we spent
+					td->info.stoptimeOpt = std::min<uint64_t>(td->info.starttime + td->info.stoptimeOptBase * nodeScalingFactor, td->info.stoptimeMax);
+				}
 			}
 		}
 		// stop calculating and return best move so far
@@ -295,9 +297,7 @@ void SearchPosition(int start_depth, int final_depth, S_ThreadData* td, S_UciOpt
 		//If it's the main thread print the uci output
 		if (td->id == 0)
 			PrintUciOutput(score, current_depth, td, options);
-
 	}
-
 }
 
 int AspirationWindowSearch(int prev_eval, int depth, S_ThreadData* td) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -284,7 +284,7 @@ void SearchPosition(int start_depth, int final_depth, S_ThreadData* td, S_UciOpt
 				// Calculate how many nodes were spent on checking the best move
 				auto bestMoveNodesFraction = 1.0 * td->nodeSpentTable[From(bestmove)][To(bestmove)] / td->info.nodes;
 				//Scale the search time based on how many nodes we spent
-				td->info.stoptimeMax = td->info + info->goodTimeLim  * bestMoveNodesFraction;
+				td->info.stoptimeOpt = td->info.starttime + td->info.stoptimeOptBase * bestMoveNodesFraction;
 			}
 		}
 		// stop calculating and return best move so far

--- a/src/search.h
+++ b/src/search.h
@@ -24,6 +24,7 @@ typedef struct ThreadData {
 	Search_data ss;
 	S_SearchINFO info;
 	PvTable pv_table;
+	uint64_t nodeSpentTable[Board_sq_num][Board_sq_num];
 	int RootDepth;
 }S_ThreadData;
 

--- a/src/search.h
+++ b/src/search.h
@@ -24,7 +24,7 @@ typedef struct ThreadData {
 	Search_data ss;
 	S_SearchINFO info;
 	PvTable pv_table;
-	uint64_t nodeSpentTable[Board_sq_num][Board_sq_num];
+	uint64_t nodeSpentTable[Board_sq_num][Board_sq_num] = { {0} };
 	int RootDepth;
 }S_ThreadData;
 

--- a/src/time_manager.cpp
+++ b/src/time_manager.cpp
@@ -7,17 +7,16 @@
 void Optimum(S_SearchINFO* info, int time, int inc) {
 	//Reserve some time overhead to avoid timing out in the engine-gui communication process
 	int safety_overhead = 50;
+	time -= safety_overhead;
 	//if we recieved a movetime command we need to spend exactly that amount of time on the move, so we don't scale
 	if (info->movetimeset)
 	{
-		time -= safety_overhead;
 		info->stoptimeMax = info->starttime + time;
 		info->stoptimeOpt = info->starttime + time;
 	}
 	//else If we recieved a movestogo parameter we use total_time/movestogo
 	else if (info->timeset && info->movestogo != -1)
 	{
-		time -= safety_overhead;
 		//Divide the time you have left for how many moves you have to play
 		auto basetime = time / info->movestogo;
 		//Never use more than 80% of the total time left for a single move
@@ -33,9 +32,7 @@ void Optimum(S_SearchINFO* info, int time, int inc) {
 	// else if we recieved wtime/btime we calculate an over and upper bound for the time usage based on fixed coefficients
 	else if (info->timeset)
 	{
-		time -= safety_overhead;
-		int time_slot = time / 20 + inc / 2;
-		int basetime = (time_slot);
+		int basetime = time / 20 + inc / 2;
 		//optime is the time we use to stop if we just cleared a depth
 		int optime = basetime * 0.6;
 		//maxtime is the absolute maximum time we can spend on a search

--- a/src/time_manager.cpp
+++ b/src/time_manager.cpp
@@ -27,7 +27,8 @@ void Optimum(S_SearchINFO* info, int time, int inc) {
 		//maxtime is the absolute maximum time we can spend on a search (unless it is bigger than the bound)
 		auto maxtime = std::min(3.0 * basetime, maxtimeBound);
 		info->stoptimeMax = info->starttime + maxtime;
-		info->stoptimeOpt = info->starttime + optime;
+		info->stoptimeOptBase = info->starttime + optime;
+		info->stoptimeOpt = info->stoptimeOptBase;
 	}
 	// else if we recieved wtime/btime we calculate an over and upper bound for the time usage based on fixed coefficients
 	else if (info->timeset)
@@ -40,7 +41,8 @@ void Optimum(S_SearchINFO* info, int time, int inc) {
 		//maxtime is the absolute maximum time we can spend on a search
 		int maxtime = std::min(time, basetime * 2);
 		info->stoptimeMax = info->starttime + maxtime;
-		info->stoptimeOpt = info->starttime + optime;
+		info->stoptimeOptBase = info->starttime + optime;
+		info->stoptimeOpt = info->stoptimeOptBase;
 	}
 }
 

--- a/src/time_manager.cpp
+++ b/src/time_manager.cpp
@@ -27,8 +27,8 @@ void Optimum(S_SearchINFO* info, int time, int inc) {
 		//maxtime is the absolute maximum time we can spend on a search (unless it is bigger than the bound)
 		auto maxtime = std::min(3.0 * basetime, maxtimeBound);
 		info->stoptimeMax = info->starttime + maxtime;
-		info->stoptimeOptBase = info->starttime + optime;
-		info->stoptimeOpt = info->stoptimeOptBase;
+		info->stoptimeBaseOpt = optime;
+		info->stoptimeOpt = info->starttime + info->stoptimeBaseOpt;
 	}
 	// else if we recieved wtime/btime we calculate an over and upper bound for the time usage based on fixed coefficients
 	else if (info->timeset)
@@ -41,8 +41,8 @@ void Optimum(S_SearchINFO* info, int time, int inc) {
 		//maxtime is the absolute maximum time we can spend on a search
 		int maxtime = std::min(time, basetime * 2);
 		info->stoptimeMax = info->starttime + maxtime;
-		info->stoptimeOptBase = info->starttime + optime;
-		info->stoptimeOpt = info->stoptimeOptBase;
+		info->stoptimeBaseOpt = optime;
+		info->stoptimeOpt = info->starttime + info->stoptimeBaseOpt;
 	}
 }
 


### PR DESCRIPTION
A big thanks to Kimmy from the Koivisto team for getting me to look at this again.

ELO   | 19.84 +- 7.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 4224 W: 1171 L: 930 D: 2123

ELO   | 15.86 +- 6.46 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 5392 W: 1431 L: 1185 D: 2776

