### PR TITLE
Do LMP at higher depths

### DIFF
--- a/Contributors
+++ b/Contributors
@@ -1,6 +1,7 @@
 # Everyone that significantly contributed to Alex code (in alphabetical order)
 Cosmo - relative NNUE inference code
 Disservin - Makefile PR
+Kimmy - Search stuff
 Luecx - Help setting up the first non relative NNUE
 Nanopixel - TM code suggestion
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -544,7 +544,7 @@ moves_loop:
 			//Movecount pruning: if we searched enough quiet moves and we are not in check we skip the others
 			if (!pv_node
 				&& !in_check
-				&& depth < 4
+				&& depth < 9
 				&& isQuiet
 				&& moves_searched > lmp_margin[depth][improving])
 			{


### PR DESCRIPTION
bench: 3254082

STC:
ELO   | 6.79 +- 4.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 13928 W: 3590 L: 3318 D: 7020
https://chess.swehosting.se/test/1284/

LTC:
ELO   | 9.40 +- 4.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 9464 W: 2403 L: 2147 D: 4914
https://chess.swehosting.se/test/1291/
