### PR TITLE
Change history heuristic table

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -6,14 +6,14 @@ void updateHHScore(const S_Board* pos, Search_data* ss, int move, int bonus)
 	//Scale bonus to fix it in a [-32768;32768] range
 	int scaled_bonus = bonus - GetHHScore(pos, ss, move) * std::abs(bonus) / 32768;
 	//Update move score
-	ss->searchHistory[pos->pieces[From(move)]]
+	ss->searchHistory[pos->side][From(move)]
 		[To(move)] += scaled_bonus;
 }
 
 void updateCHScore(const S_Board* pos, Search_data* sd, const Search_stack* ss, const int move, const int bonus)
 {
 	//Scale bonus to fix it in a [-32768;32768] range
-	int scaled_bonus = bonus - GetCHScore( sd, ss, move) * std::abs(bonus) / 32768;
+	int scaled_bonus = bonus - GetCHScore(sd, ss, move) * std::abs(bonus) / 32768;
 	//Update move score
 	if (ss->ply > 0)
 	{
@@ -65,7 +65,7 @@ void UpdateCH(const S_Board* pos, Search_data* sd, const Search_stack* ss, const
 
 //Returns the history score of a move
 int GetHHScore(const S_Board* pos, const Search_data* sd, const int  move) {
-	return sd->searchHistory[pos->pieces[From(move)]][To(move)];
+	return sd->searchHistory[pos->side][From(move)][To(move)];
 }
 
 int GetHistoryScore(const S_Board* pos, const Search_data* sd, const int  move, const Search_stack* ss) {
@@ -85,7 +85,8 @@ void CleanHistories(Search_data* ss) {
 	//For every piece [12] moved to every square [64] we reset the searchHistory value
 	for (int index = 0; index < 12; ++index) {
 		for (int index2 = 0; index2 < 64; ++index2) {
-			ss->searchHistory[index][index2] = 0;
+			ss->searchHistory[WHITE][index][index2] = 0;
+			ss->searchHistory[BLACK][index][index2] = 0;
 		}
 	}
 	std::memset(ss->cont_hist, 0, sizeof(ss->cont_hist));

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -83,7 +83,7 @@ int GetCHScore(const Search_data* sd, const Search_stack* ss, const int  move)
 //Resets the history table
 void CleanHistories(Search_data* ss) {
 	//For every piece [12] moved to every square [64] we reset the searchHistory value
-	for (int index = 0; index < 12; ++index) {
+	for (int index = 0; index < 64; ++index) {
 		for (int index2 = 0; index2 < 64; ++index2) {
 			ss->searchHistory[WHITE][index][index2] = 0;
 			ss->searchHistory[BLACK][index][index2] = 0;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -528,6 +528,8 @@ moves_loop:
 
 		if (isQuiet && SkipQuiets) continue;
 
+		int movehistory = GetHistoryScore(pos, sd, move, ss);
+
 		//if the move isn't a quiet move we update the quiet moves list and counter
 		if (isQuiet) {
 			quiet_moves.moves[quiet_moves.count].move = move;
@@ -616,7 +618,6 @@ moves_loop:
 				depth_reduction += !improving;
 				//Reduce more if we aren't in a pv node
 				depth_reduction += !pv_node;
-				int movehistory = GetHistoryScore(pos, sd, move, ss);
 				//Decrease the reduction for moves that have a good history score
 				if (movehistory > 16384) depth_reduction--;
 			}

--- a/src/search.h
+++ b/src/search.h
@@ -12,7 +12,7 @@ struct Search_stack {
 };
 
 struct Search_data {
-	int searchHistory[12][Board_sq_num] = { 0 };
+	int searchHistory[2][Board_sq_num][Board_sq_num] = { 0 };
 	int CounterMoves[Board_sq_num][Board_sq_num] = { 0 };
 	int cont_hist[12][64][12][64] = { 0 };
 };


### PR DESCRIPTION
ELO   | 4.82 +- 3.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 21392 W: 5497 L: 5200 D: 10695

ELO   | 5.48 +- 3.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 17768 W: 4370 L: 4090 D: 9308