### PR TITLE
Use a bigger fraction of the increment for TMs that have one 

### DIFF
--- a/src/time_manager.cpp
+++ b/src/time_manager.cpp
@@ -32,7 +32,7 @@ void Optimum(S_SearchINFO* info, int time, int inc) {
 	// else if we recieved wtime/btime we calculate an over and upper bound for the time usage based on fixed coefficients
 	else if (info->timeset)
 	{
-		int basetime = time / 20 + inc / 2;
+		int basetime = time / 20 + inc * 3 / 4;
 		//optime is the time we use to stop if we just cleared a depth
 		int optime = basetime * 0.6;
 		//maxtime is the absolute maximum time we can spend on a search


### PR DESCRIPTION
ELO   | 3.65 +- 2.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 31336 W: 7856 L: 7527 D: 15953

ELO   | 4.05 +- 2.90 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 26712 W: 6631 L: 6320 D: 13761