### PR TITLE
Increase lmr reduction for moves with a bad history score

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -620,6 +620,7 @@ moves_loop:
 				depth_reduction += !pv_node;
 				//Decrease the reduction for moves that have a good history score
 				if (movehistory > 16384) depth_reduction--;
+				if (movehistory < -16384) depth_reduction++;
 			}
 			//Reduce tacticals too but only if we aren't on a pv node
 			else if (!pv_node) {


### PR DESCRIPTION
ELO   | 3.34 +- 2.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 35496 W: 8922 L: 8581 D: 17993

ELO   | 2.96 +- 2.57 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.36 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 33576 W: 8211 L: 7925 D: 17440

Bench: 3449068