### PR TITLE
Move bad captures after all quiet moves, no matter the history score

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -188,9 +188,16 @@ static inline void score_moves(S_Board* pos, Search_data* sd, Search_stack* ss, 
 		}
 		//if the move is a capture sum the mvv-lva score to a variable that depends on whether the capture has a good SEE or not 
 		else if (IsCapture(move)) {
-			move_list->moves[i].score =
-				mvv_lva[Piece(move)][PieceOn(pos, To(move))] +
-				goodCaptureScore * SEE(pos, move, -107);
+			//Good captures get played before most of the stuff
+			if (SEE(pos, move, -107)) {
+				move_list->moves[i].score =
+					mvv_lva[Piece(move)][PieceOn(pos, To(move))] +
+					goodCaptureScore;
+			}
+			else {
+				move_list->moves[i].score = -100000 + mvv_lva[Piece(move)][PieceOn(pos, To(move))];
+			}
+
 			continue;
 		}
 		//First  killer move always comes after the TT move,the promotions and the good captures and before anything else


### PR DESCRIPTION
Prevents some weird interactions with capture history
ELO   | 1.47 +- 4.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.17 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 12528 W: 3086 L: 3033 D: 6409
Bench: 8868607