### PR TITLE
Reduce moves that give check less

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -640,11 +640,13 @@ moves_loop:
 				depth_reduction -= std::clamp(movehistory / 16384, -1, 1);
 				//Fuck
 				depth_reduction += 2 * cutnode;
+				if (pos->checkers) depth_reduction -= 1;
 			}
 			//Reduce tacticals too but only if we aren't on a pv node
 			else if (!pv_node) {
 				//calculate by how much we should reduce the search depth (ideally this needs its own table, but i'm lazy)
 				depth_reduction = reductions[depth][moves_searched];
+				if (pos->checkers) depth_reduction -= 1;
 			}
 			//adjust the reduction so that we can't drop into Qsearch and to prevent extensions
 			depth_reduction = std::min(depth - 1, std::max(depth_reduction, 1));


### PR DESCRIPTION
ELO   | 2.61 +- 2.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 51992 W: 12751 L: 12361 D: 26880

Bench: 8520603