### PR TITLE
Adjust Qsearch eval based on TT score

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -788,14 +788,15 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 	//If we have a ttHit with a valid eval use that
 	if (TThit)
 	{
-		eval = ss->static_eval = (tte.eval != value_none) ? tte.eval : EvalPosition(pos);
+		ss->static_eval = (tte.eval != value_none) ? tte.eval : EvalPosition(pos);
+		eval = BestScore = ttScore;
 	}
 	else
 	{
 		//If we don't have any useful info in the TT just call Evalpos
-		eval = ss->static_eval = EvalPosition(pos);
+		eval = BestScore = ss->static_eval = EvalPosition(pos);
 	}
-	BestScore = eval;
+
 	//Stand pat
 	if (eval >= beta) return eval;
 	//Adjust alpha based on eval


### PR DESCRIPTION
ELO   | 5.50 +- 3.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 18016 W: 4512 L: 4227 D: 9277

Bench: 7098629