### PR TITLE
Propagate mate scores from Qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -864,6 +864,11 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 		}
 	}
 
+	if (move_list->count == 0 && in_check) {
+		// return mate score (assuming closest distance to mating position)
+		BestScore = (-mate_value + ss->ply);
+	}
+
 	//Set the TT flag based on whether the BestScore is better than beta, for qsearch we never use the exact flag
 	int flag = BestScore >= beta ? HFBETA : HFALPHA;
 


### PR DESCRIPTION
ELO   | 1.06 +- 2.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 32528 W: 7944 L: 7845 D: 16739