### PR TITLE
Do IIR on positions without a TThit instead of positions without a TT move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -419,7 +419,7 @@ int Negamax(int alpha, int beta, int depth, bool cutnode, S_ThreadData* td, Sear
     // IIR by Ed Schroder (That i find out about in Berserk source code)
     // http://talkchess.com/forum3/viewtopic.php?f=7&t=74769&sid=64085e3396554f0fba414404445b3120
     // https://github.com/jhonnold/berserk/blob/dd1678c278412898561d40a31a7bd08d49565636/src/search.c#L379
-    if (depth >= 4 && !tte.move && !excludedMove)
+    if (depth >= 4 && !ttHit && !excludedMove)
         depth--;
 
     // If we are in check or searching a singular extension we avoid pruning before the move loop


### PR DESCRIPTION
ELO   | 7.77 +- 4.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 11808 W: 3018 L: 2754 D: 6036

Bench: 9960849