### PR TITLE
Rework check extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -366,8 +366,6 @@ int Negamax(int alpha, int beta, int depth, bool cutnode, S_ThreadData* td, Sear
 	int excludedMove = ss->excludedMove;
 
 	pv_table->pvLength[ss->ply] = ss->ply;
-	// Prevent dropping into Qsearch if in check and generally extend search by 1
-	if (in_check) depth = std::max(1, depth + 1);
 
 	// Check for the highest depth reached in search to report it to the cli
 	if (ss->ply > info->seldepth)
@@ -590,6 +588,9 @@ moves_loop:
 					return (singularBeta);
 
 			}
+
+			else if (pos->checkers && depth > 8)
+				extension = 1;
 		}
 		// we adjust the search depth based on potential extensions
 		int newDepth = depth + extension;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -589,7 +589,7 @@ moves_loop:
 
 			}
 
-			else if (pos->checkers && depth > 8)
+			else if (pos->checkers)
 				extension = 1;
 		}
 		// we adjust the search depth based on potential extensions


### PR DESCRIPTION
Reworks check extension to allow a drop into Qsearch and to make it fall under the maximum extension limit applied to SE
ELO   | 1.50 +- 2.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.53 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 36256 W: 9000 L: 8843 D: 18413

Adjusted LLR with non regr [-3, 1] bounds: 4.06

Bench: 9232576