### PR TITLE
Decrease search depth in AWSearch on a fail high 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -326,11 +326,13 @@ int AspirationWindowSearch(int prev_eval, int depth, S_ThreadData* td) {
 		if ((score <= alpha)) {
 			beta = (alpha + beta) / 2;
 			alpha = std::max(-MAXSCORE, score - delta);
+			depth = td->RootDepth;
 		}
 
 		// We fell outside the window, so try again with a bigger window
 		else if ((score >= beta)) {
 			beta = std::min(score + delta, MAXSCORE);
+			depth = std::max(depth - 1, td->RootDepth - 5);
 		}
 		else break;
 		// Progressively increase how much the windows are increased by at each fail


### PR DESCRIPTION
ELO   | 2.93 +- 2.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 42912 W: 10508 L: 10146 D: 22258

Bench: 9042370