### PR TITLE
Do more singular extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -590,7 +590,7 @@ moves_loop:
 				&& (tte.flags & HFLOWER)
 				&& abs(ttScore) < mate_score
 				&& tte.depth >= depth - 3) {
-				const int singularBeta = ttScore - 2 * depth;
+				const int singularBeta = ttScore - depth;
 				const int singularDepth = (depth - 1) / 2;
 
 				ss->excludedMove = ttmove;


### PR DESCRIPTION
Tested at 20+0.2:
```
ELO   | 7.42 +- 4.21 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 12224 W: 2992 L: 2731 D: 6501
```
https://chess.swehosting.se/test/3191/

Bench: 12889204