### PR TITLE
Do one less full move for lmr

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -629,7 +629,7 @@ moves_loop:
 		uint64_t nodes_before_search = info->nodes;
 		bool do_full_search = false;
 		// conditions to consider LMR
-		if (moves_searched >= 3 + 2 * pv_node && depth >= 3) {
+		if (moves_searched >= 2 + 2 * pv_node && depth >= 3) {
 			int depth_reduction = 1;
 			if (isQuiet || !ttpv) {
 				// calculate by how much we should reduce the search depth


### PR DESCRIPTION
ELO   | 5.20 +- 3.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 19120 W: 4753 L: 4467 D: 9900
https://chess.swehosting.se/test/3323/
Bench: 11581833