### PR TITLE
Use global nnue params

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -363,8 +363,8 @@ uint64_t GetMaterialValue(const S_Board* pos) {
 
 void Accumulate(NNUE::accumulator& board_accumulator, S_Board* pos) {
     for (int i = 0; i < HIDDEN_SIZE; i++) {
-        board_accumulator[0][i] = nnue.featureBias[i];
-        board_accumulator[1][i] = nnue.featureBias[i];
+        board_accumulator[0][i] = net.featureBias[i];
+        board_accumulator[1][i] = net.featureBias[i];
     }
 
     for (int i = 0; i < 64; i++) {

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -23,7 +23,7 @@ const unsigned int gEVALSize = 1;
 
 Network net;
 
-// Thanks to Disservin for having me look at his code and Lucex for the
+// Thanks to Disservin for having me look at his code and Luecx for the
 // invaluable help and the immense patience
 
 int32_t NNUE::SCReLU(int16_t x) {

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -6,6 +6,15 @@
 constexpr int INPUT_WEIGHTS = 768;
 constexpr int HIDDEN_SIZE = 768;
 
+struct  Network {
+     int16_t featureWeights[INPUT_WEIGHTS * HIDDEN_SIZE];
+     int16_t featureBias[HIDDEN_SIZE];
+     int16_t outputWeights[HIDDEN_SIZE * 2];
+     int16_t outputBias;
+};
+
+extern Network net;
+
 class NNUE {
 public:
     using accumulator = std::array<std::array<int16_t, HIDDEN_SIZE>, 2>;
@@ -18,9 +27,4 @@ public:
     [[nodiscard]] int32_t output(const NNUE::accumulator& board_accumulator, bool whiteToMove);
     void Clear(NNUE::accumulator& board_accumulator);
     [[nodiscard]] std::pair<std::size_t, std::size_t> GetIndex(int piece, int square);
-
-    int16_t featureWeights[INPUT_WEIGHTS * HIDDEN_SIZE];
-    int16_t featureBias[HIDDEN_SIZE];
-    int16_t outputWeights[HIDDEN_SIZE * 2];
-    int16_t outputBias;
 };

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -6,11 +6,11 @@
 constexpr int INPUT_WEIGHTS = 768;
 constexpr int HIDDEN_SIZE = 768;
 
-struct  Network {
-     int16_t featureWeights[INPUT_WEIGHTS * HIDDEN_SIZE];
-     int16_t featureBias[HIDDEN_SIZE];
-     int16_t outputWeights[HIDDEN_SIZE * 2];
-     int16_t outputBias;
+struct Network {
+    int16_t featureWeights[INPUT_WEIGHTS * HIDDEN_SIZE];
+    int16_t featureBias[HIDDEN_SIZE];
+    int16_t outputWeights[HIDDEN_SIZE * 2];
+    int16_t outputBias;
 };
 
 extern Network net;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,8 +73,8 @@ void ClearForSearch(S_ThreadData* td) {
 	info->seldepth = 0;
 	// Main thread only unpauses any eventual search thread
 	if (td->id == 0) {
-		for (auto& td : threads_data) {
-			td.info.stopped = false;
+		for (auto& helper_thread : threads_data) {
+			helper_thread.info.stopped = false;
 		}
 	}
 }

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-4.0.19"
+#define NAME "Alexandria-4.0.20"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
Avoids having to supply a copy of the nnue params to each and any thread data object