### PR TITLE
Introduce verification search to detect zugzwangs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -514,12 +514,12 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 				if (nmpScore > mate_score) nmpScore = beta;
 
 				// If we don't have to do a verification search just return the score
-				if (td->nmpPlies || depth < 15) {
+				if (td->nmpPlies || depth < 12) {
 					return nmpScore;
 				}
 				// Verification search to avoid zugzwangs: if we are at an high enough depth we perform another reduced search without nmp for at least nmpPlies
-				td->nmpPlies = ss->ply + (depth - R) * 3/4;
-				int verification_score = Negamax( beta - 1, beta,  depth - R, false, td,ss);
+				td->nmpPlies = ss->ply + (depth - R) * 2 / 3;
+				int verification_score = Negamax<false>(beta - 1, beta, depth - R, false, td, ss);
 				td->nmpPlies = 0;
 
 				// If the verification search holds return the score

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -514,7 +514,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 				if (nmpScore > mate_score) nmpScore = beta;
 
 				// If we don't have to do a verification search just return the score
-				if (td->nmpPlies || depth < 12) {
+				if (td->nmpPlies || depth < 15) {
 					return nmpScore;
 				}
 				// Verification search to avoid zugzwangs: if we are at an high enough depth we perform another reduced search without nmp for at least nmpPlies

--- a/src/search.h
+++ b/src/search.h
@@ -28,6 +28,7 @@ struct S_ThreadData {
     PvTable pv_table;
     uint64_t nodeSpentTable[Board_sq_num][Board_sq_num] = {};
     int RootDepth;
+    int nmpPlies;
 };
 
 // ClearForSearch handles the cleaning of the thread data from a clean state

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-4.0.21"
+#define NAME "Alexandria-4.0.22"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
```
ELO: -0.404 +- 2.29 [-2.69, 1.88]
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR: 3.22 [-5.0, 1.0] (-2.94, 2.94)
GAMES | N: 41248 W: 9586 L: 9634 D: 22028
```