### PR TITLE
Increase TTKey size to 32 bits

### DIFF
--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -41,11 +41,10 @@ void StoreHashEntry(const ZobristKey key, const int16_t move, int score, int16_t
     // Overwrite less valuable entries (cheapest checks first)
     if (flags == HFEXACT || static_cast<TTKey>(key) != tte->tt_key || depth + 11 + 2 * pv > tte->depth) {
         tte->tt_key = static_cast<TTKey>(key);
-        tte->flags = static_cast<uint8_t>(flags);
+        tte->wasPv_flags = static_cast<uint8_t>(flags + (wasPv << 2));
         tte->score = static_cast<int16_t>(score);
         tte->eval = eval;
         tte->depth = static_cast<uint8_t>(depth);
-        tte->wasPv = wasPv;
     }
 }
 

--- a/src/ttable.h
+++ b/src/ttable.h
@@ -11,8 +11,7 @@ PACK(struct S_HashEntry {
     int16_t eval = 0;
     TTKey tt_key = 0;
     uint8_t depth = 0;
-    uint8_t flags = HFNONE;
-    bool wasPv = false;
+    uint8_t wasPv_flags = HFNONE;
 });
 
 struct S_HashTable {

--- a/src/types.h
+++ b/src/types.h
@@ -7,7 +7,7 @@
 // define bitboard data type
 using Bitboard = uint64_t;
 // define poskey data type
-using TTKey = uint16_t;
+using TTKey = uint32_t;
 // define poskey data type
 using ZobristKey = uint64_t;
 

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-4.0.26"
+#define NAME "Alexandria-4.0.27"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
ELO   | 1.08 +- 2.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 1.00]
GAMES | N: 32240 W: 7557 L: 7457 D: 17226

Bench: 11074335