### PR TITLE
Prevent wrong TT flags when not TT hit

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -162,7 +162,7 @@ std::string Pick_color(int score) {
     // drawish score, no highlight
     if (abs(score) <= 10) return "\033[38;5;7m";
     // Good mate score, blue
-    if (score > mate_score) return "\033[38;5;39m";
+    if (score > mate_found) return "\033[38;5;39m";
     // positive for us, light green
     if (score > 10) return "\033[38;5;42m";
     // negative for us, red
@@ -178,12 +178,12 @@ void PrintUciOutput(const int score, const int depth, const S_ThreadData* td, co
 
     uint64_t nps = nodes / (time + !time) * 1000;
     if (print_uci) {
-        if (score > -mate_value && score < -mate_score)
-            std::cout << "info score mate " << -(score + mate_value) / 2 << " depth " << depth << " seldepth " << td->info.seldepth << " multipv " << options->MultiPV << " nodes " << nodes <<
+        if (score > -mate_score && score < -mate_found)
+            std::cout << "info score mate " << -(score + mate_score) / 2 << " depth " << depth << " seldepth " << td->info.seldepth << " multipv " << options->MultiPV << " nodes " << nodes <<
             " nps " << nps << " time " << GetTimeMs() - td->info.starttime << " pv ";
 
-        else if (score > mate_score && score < mate_value)
-            std::cout << "info score mate " << (mate_value - score) / 2 + 1 << " depth " << depth << " seldepth " << td->info.seldepth << " multipv " << options->MultiPV << " nodes " << nodes <<
+        else if (score > mate_found && score < mate_score)
+            std::cout << "info score mate " << (mate_score - score) / 2 + 1 << " depth " << depth << " seldepth " << td->info.seldepth << " multipv " << options->MultiPV << " nodes " << nodes <<
             " nps " << nps << " time " << GetTimeMs() - td->info.starttime << " pv ";
 
         else
@@ -222,12 +222,12 @@ void PrintUciOutput(const int score, const int depth, const S_ThreadData* td, co
         int score_precision = 0;
         float parsed_score = 0;
         std::string score_unit;
-        if (score > -mate_value && score < -mate_score) {
-            parsed_score = std::abs((score + mate_value) / 2);
+        if (score > -mate_score && score < -mate_found) {
+            parsed_score = std::abs((score + mate_score) / 2);
             score_unit = "-M";
         }
-        else if (score > mate_score && score < mate_value) {
-            parsed_score = (mate_value - score) / 2 + 1;
+        else if (score > mate_found && score < mate_score) {
+            parsed_score = (mate_score - score) / 2 + 1;
             score_unit = "+M";
         }
         else {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -17,7 +17,7 @@
 #include <algorithm>
 
 // Returns true if the position is a 2-fold repetition, false otherwise
-static bool IsRepetition(const S_Board* pos, const bool pv_node) {
+static bool IsRepetition(const S_Board* pos, const bool pvNode) {
 	assert(pos->hisPly >= pos->fiftyMove);
 	int counter = 1;
 	// we only need to check for repetition the moves since the last 50mr reset
@@ -27,7 +27,7 @@ static bool IsRepetition(const S_Board* pos, const bool pv_node) {
 		if (pos->played_positions[index] == pos->posKey) {
 			// we found a repetition
 			counter++;
-			if(counter >= 2 + pv_node) return true;
+			if(counter >= 2 + pvNode) return true;
 		}
 
 	return false;
@@ -49,9 +49,9 @@ static bool Is50MrDraw(S_Board* pos) {
 }
 
 // If we triggered any of the rules that forces a draw or we know the position is a draw return a draw score
-bool IsDraw(S_Board* pos, const bool pv_node) {
+bool IsDraw(S_Board* pos, const bool pvNode) {
 	// if it's a 3-fold repetition, the fifty moves rule kicked in or there isn't enough material on the board to give checkmate then it's a draw
-	return IsRepetition(pos, pv_node)
+	return IsRepetition(pos, pvNode)
 		|| Is50MrDraw(pos)
 		|| MaterialDraw(pos);
 }
@@ -355,8 +355,8 @@ int AspirationWindowSearch(int prev_eval, int depth, S_ThreadData* td) {
 }
 
 // Negamax alpha beta search
-template <bool pv_node>
-int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td, Search_stack* ss) {
+template <bool pvNode>
+int Negamax(int alpha, int beta, int depth, const bool cutNode, S_ThreadData* td, Search_stack* ss) {
 	// Extract data structures from ThreadData
 	S_Board* pos = &td->pos;
 	Search_data* sd = &td->ss;
@@ -372,7 +372,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 	bool improving = false;
 	int Score = -MAXSCORE;
 	S_HashEntry tte;
-	bool ttpv = pv_node;
+	bool ttpv = pvNode;
 
 	const int excludedMove = ss->excludedMove;
 
@@ -384,7 +384,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 
 	// recursion escape condition
 	if (depth <= 0) {
-		return Quiescence<pv_node>(alpha, beta, td, ss);
+		return Quiescence<pvNode>(alpha, beta, td, ss);
 	}
 
 	// check if more than Maxtime passed and we have to stop
@@ -396,7 +396,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 	// Check for early return conditions
 	if (!root_node) {
 		// If position is a draw return a randomized draw score to avoid 3-fold blindness
-		if (IsDraw(pos, pv_node)) {
+		if (IsDraw(pos, pvNode)) {
 			return 8 - (info->nodes & 7);
 		}
 
@@ -418,7 +418,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 	const int ttMove = ttHit ? MoveFromTT(tte.move, pos->PieceOn(From(tte.move))) : NOMOVE;
 	const uint8_t ttFlag = ttHit ? tte.wasPv_flags & 3 : HFNONE;
 	// If we found a value in the TT for this position, and the depth is equal or greater we can return it (pv nodes are excluded)
-	if (!pv_node
+	if (!pvNode
 		&& ttScore != score_none
 		&& tte.depth >= depth) {
 		if ((ttFlag == HFUPPER && ttScore <= alpha)
@@ -428,7 +428,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 	}
 
 	if (ttHit)
-		ttpv = pv_node || (tte.wasPv_flags >> 2);
+		ttpv = pvNode || (tte.wasPv_flags >> 2);
 
 	// IIR by Ed Schroder (That i find out about in Berserk source code)
 	// http://talkchess.com/forum3/viewtopic.php?f=7&t=74769&sid=64085e3396554f0fba414404445b3120
@@ -460,7 +460,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 		if (!excludedMove)
 		{
 	    	// Save the eval into the TT
-	    	StoreHashEntry(pos->posKey, NOMOVE, score_none, eval, HFNONE, 0, pv_node, ttpv);
+	    	StoreHashEntry(pos->posKey, NOMOVE, score_none, eval, HFNONE, 0, pvNode, ttpv);
 		}
 	}
 
@@ -482,7 +482,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 	(ss + 1)->searchKillers[0] = NOMOVE;
 	(ss + 1)->searchKillers[1] = NOMOVE;
 
-	if (!pv_node) {
+	if (!pvNode) {
 		// Reverse futility pruning
 		if (depth < 9
 			&& eval - 66 * (depth - improving) >= beta
@@ -502,7 +502,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 			int R = 3 + depth / 3 + std::min((eval - beta) / 200, 3);
 			/* search moves with reduced depth to find beta cutoffs
 			   depth - 1 - R where R is a reduction limit */
-			int nmpScore = -Negamax<false>(-beta, -beta + 1, depth - R, !cutnode, td, ss + 1);
+			int nmpScore = -Negamax<false>(-beta, -beta + 1, depth - R, !cutNode, td, ss + 1);
 
 			TakeNullMove(pos);
 
@@ -568,7 +568,7 @@ moves_loop:
 			&& BoardHasNonPawns(pos, pos->side)
 			&& BestScore > -mate_found) {
 			// Movecount pruning: if we searched enough moves and we are not in check we skip the rest
-			if (!pv_node
+			if (!pvNode
 				&& !in_check
 				&& depth < 9
 				&& isQuiet
@@ -611,13 +611,13 @@ moves_loop:
 				const int singularDepth = (depth - 1) / 2;
 
 				ss->excludedMove = ttMove;
-				int singularScore = Negamax<false>(singularBeta - 1, singularBeta, singularDepth, cutnode, td, ss);
+				int singularScore = Negamax<false>(singularBeta - 1, singularBeta, singularDepth, cutNode, td, ss);
 				ss->excludedMove = NOMOVE;
 
 				if (singularScore < singularBeta) {
 					extension = 1;
 					// Avoid search explosion by limiting the number of double extensions
-					if (!pv_node
+					if (!pvNode
 						&& singularScore < singularBeta - 17
 						&& ss->double_extensions <= 11) {
 						extension = 2;
@@ -646,7 +646,7 @@ moves_loop:
 		uint64_t nodes_before_search = info->nodes;
 		bool do_full_search = false;
 		// conditions to consider LMR
-		if (moves_searched >= 2 + 2 * pv_node && depth >= 3) {
+		if (moves_searched >= 2 + 2 * pvNode && depth >= 3) {
 			int depth_reduction = 1;
 			if (isQuiet || !ttpv) {
 				// calculate by how much we should reduce the search depth
@@ -659,7 +659,7 @@ moves_loop:
 				// Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
 				depth_reduction -= std::clamp(movehistory / 16384, -2, 2);
 				// Fuck
-				depth_reduction += 2 * cutnode;
+				depth_reduction += 2 * cutNode;
 				// Decrease the reduction for moves that give check
 				if (pos->checkers) depth_reduction -= 1;
 			}
@@ -672,14 +672,14 @@ moves_loop:
 		}
 		else {
 			// If we skipped LMR and this isn't the first move of the node we'll search with a reduced window and full depth
-			do_full_search = !pv_node || moves_searched > 0;
+			do_full_search = !pvNode || moves_searched > 0;
 		}
 		// Search every move (excluding the first of every node) that skipped or failed LMR with full depth but a reduced window
 		if (do_full_search)
-			Score = -Negamax<false>(-alpha - 1, -alpha, newDepth - 1, !cutnode, td, ss + 1);
+			Score = -Negamax<false>(-alpha - 1, -alpha, newDepth - 1, !cutNode, td, ss + 1);
 
 		// PVS Search: Search the first move and every move that is within bounds with full depth and a full window
-		if (pv_node && (moves_searched == 0 || (Score > alpha && Score < beta)))
+		if (pvNode && (moves_searched == 0 || (Score > alpha && Score < beta)))
 			Score = -Negamax<true>(-beta, -alpha, newDepth - 1, false, td, ss + 1);
 
 		// take move back
@@ -741,13 +741,13 @@ moves_loop:
 	// Set the TT flag based on whether the BestScore is better than beta and if it's not based on if we changed alpha or not
 	int flag = BestScore >= beta ? HFLOWER : (alpha != old_alpha) ? HFEXACT : HFUPPER;
 
-	if (!excludedMove) StoreHashEntry(pos->posKey, MoveToTT(bestmove), ScoreToTT(BestScore, ss->ply), ss->static_eval, flag, depth, pv_node,ttpv);
+	if (!excludedMove) StoreHashEntry(pos->posKey, MoveToTT(bestmove), ScoreToTT(BestScore, ss->ply), ss->static_eval, flag, depth, pvNode,ttpv);
 	// return best score
 	return BestScore;
 }
 
 // Quiescence search to avoid the horizon effect
-template <bool pv_node>
+template <bool pvNode>
 int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 	S_Board* pos = &td->pos;
 	Search_data* sd = &td->ss;
@@ -756,7 +756,7 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 	// tte is an hashtable entry, it will store the values fetched from the TT
 	S_HashEntry tte;
 	int BestScore;
-	bool ttpv = pv_node;
+	bool ttpv = pvNode;
 
 	// check if more than Maxtime passed and we have to stop
 	if (td->id == 0 && TimeOver(&td->info)) {
@@ -765,7 +765,7 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 	}
 
 	// If position is a draw return a randomized draw score to avoid 3-fold blindness
-	if (IsDraw(pos, pv_node)) {
+	if (IsDraw(pos, pvNode)) {
 		return 1 - (info->nodes & 2);
 	}
 
@@ -779,7 +779,7 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 	const int ttMove = ttHit ? MoveFromTT(tte.move, pos->PieceOn(From(tte.move))) : NOMOVE;
 	const uint8_t ttFlag = ttHit ? tte.wasPv_flags & 3 : HFNONE;
 	// If we found a value in the TT we can return it
-	if (!pv_node && ttScore != score_none) {
+	if (!pvNode && ttScore != score_none) {
 		if ((ttFlag == HFUPPER && ttScore <= alpha)
 			|| (ttFlag == HFLOWER && ttScore >= beta)
 			|| (ttFlag == HFEXACT))
@@ -787,7 +787,7 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 	}
 
 	if (ttHit)
-		ttpv = pv_node || (tte.wasPv_flags >> 2);
+		ttpv = pvNode || (tte.wasPv_flags >> 2);
 
 	if (in_check) {
 		ss->static_eval = score_none;
@@ -840,7 +840,7 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 		// increment nodes count
 		info->nodes++;
 		// Call Quiescence search recursively
-		int Score = -Quiescence<pv_node>(-beta, -alpha, td, ss + 1);
+		int Score = -Quiescence<pvNode>(-beta, -alpha, td, ss + 1);
 
 		// take move back
 		UnmakeMove(move, pos);
@@ -872,7 +872,7 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 	// Set the TT flag based on whether the BestScore is better than beta, for qsearch we never use the exact flag
 	int flag = BestScore >= beta ? HFLOWER : HFUPPER;
 
-	StoreHashEntry(pos->posKey, MoveToTT(bestmove), ScoreToTT(BestScore, ss->ply), ss->static_eval, flag, 0, pv_node, ttpv);
+	StoreHashEntry(pos->posKey, MoveToTT(bestmove), ScoreToTT(BestScore, ss->ply), ss->static_eval, flag, 0, pvNode, ttpv);
 
 	// return the best score we got
 	return BestScore;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -416,7 +416,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 	const bool ttHit = excludedMove ? false : ProbeHashEntry(pos, &tte);
 	const int ttScore = ttHit ? ScoreFromTT(tte.score, ss->ply) : value_none;
 	const int ttmove = ttHit ? MoveFromTT(tte.move, pos->PieceOn(From(tte.move))) : NOMOVE;
-	const uint8_t ttFlag = tte.wasPv_flags & 3;
+	const uint8_t ttFlag = ttHit ? tte.wasPv_flags & 3 : HFNONE;
 	// If we found a value in the TT for this position, and the depth is equal or greater we can return it (pv nodes are excluded)
 	if (!pv_node
 		&& ttScore != value_none
@@ -433,7 +433,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td
 	// IIR by Ed Schroder (That i find out about in Berserk source code)
 	// http://talkchess.com/forum3/viewtopic.php?f=7&t=74769&sid=64085e3396554f0fba414404445b3120
 	// https://github.com/jhonnold/berserk/blob/dd1678c278412898561d40a31a7bd08d49565636/src/search.c#L379
-	if (depth >= 4 && (!ttHit || ttFlag == HFNONE) && !excludedMove)
+	if (depth >= 4 && ttFlag == HFNONE && !excludedMove)
 		depth--;
 
 	// If we are in check or searching a singular extension we avoid pruning before the move loop

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -777,7 +777,7 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 	const bool TThit = ProbeHashEntry(pos, &tte);
 	const int ttScore = TThit ? ScoreFromTT(tte.score, ss->ply) : value_none;
 	const int ttmove = TThit ? MoveFromTT(tte.move, pos->PieceOn(From(tte.move))) : NOMOVE;
-	const uint8_t ttFlag = tte.wasPv_flags & 3;
+	const uint8_t ttFlag = TThit ? tte.wasPv_flags & 3 : HFNONE;
 	// If we found a value in the TT we can return it
 	if (!pv_node && ttScore != value_none) {
 		if ((ttFlag == HFUPPER && ttScore <= alpha)

--- a/src/search.h
+++ b/src/search.h
@@ -41,10 +41,10 @@ void SearchPosition(int start_depth, int final_depth, S_ThreadData* td, S_UciOpt
 // Sets up aspiration windows and starts a Negamax search
 [[nodiscard]] int AspirationWindowSearch(int prev_eval, int depth, S_ThreadData* td);
 // Negamax alpha beta search
-template <bool pv_node>
-[[nodiscard]] int Negamax(int alpha, int beta, int depth, const bool cutnode, S_ThreadData* td, Search_stack* ss);
+template <bool pvNode>
+[[nodiscard]] int Negamax(int alpha, int beta, int depth, const bool cutNode, S_ThreadData* td, Search_stack* ss);
 // Quiescence search to avoid the horizon effect
-template <bool pv_node>
+template <bool pvNode>
 [[nodiscard]] int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss);
 
 [[nodiscard]] int GetBestMove(const PvTable* pv_table);
@@ -52,4 +52,4 @@ template <bool pv_node>
 // inspired by the Weiss engine
 [[nodiscard]] bool SEE(const S_Board* pos, const int move, const int threshold);
 // Checks if the current position is a draw
-[[nodiscard]] bool IsDraw(S_Board* pos, const bool pv_node);
+[[nodiscard]] bool IsDraw(S_Board* pos, const bool pvNode);

--- a/src/ttable.h
+++ b/src/ttable.h
@@ -7,8 +7,8 @@
 
 PACK(struct S_HashEntry {
     int16_t move = NOMOVE;
-    int16_t score = 0;
-    int16_t eval = 0;
+    int16_t score = score_none;
+    int16_t eval = score_none;
     TTKey tt_key = 0;
     uint8_t depth = 0;
     uint8_t wasPv_flags = HFNONE;

--- a/src/types.h
+++ b/src/types.h
@@ -17,7 +17,7 @@ constexpr int Board_sq_num = 64;
 constexpr int NOMOVE = 0;
 constexpr int mate_value = 32000;
 constexpr int mate_score = mate_value - MAXPLY;
-constexpr int value_none = 32001;
+constexpr int score_none = 32001;
 constexpr int MAXSCORE = 32670;
 
 // board squares

--- a/src/types.h
+++ b/src/types.h
@@ -15,8 +15,8 @@ constexpr int MAXPLY = 128;
 constexpr int MAXDEPTH = MAXPLY;
 constexpr int Board_sq_num = 64;
 constexpr int NOMOVE = 0;
-constexpr int mate_value = 32000;
-constexpr int mate_score = mate_value - MAXPLY;
+constexpr int mate_score = 32000;
+constexpr int mate_found = mate_score - MAXPLY;
 constexpr int score_none = 32001;
 constexpr int MAXSCORE = 32670;
 


### PR DESCRIPTION
Also includes other cleanups and simplifications.

```
ELO   | 0.07 +- 1.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
GAMES | N: 72800 W: 17133 L: 17119 D: 38548
https://chess.swehosting.se/test/3746/
```
Bench 11074335