### PR TITLE
Dampen Eval as the 50 move rule approaches

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -217,19 +217,15 @@ void ParseFen(const std::string& command, S_Board* pos) {
         pos->hisPly = 0;
     }
 
-    // loop over white pieces pos->pos->bitboards
     for (int piece = WP; piece <= WK; piece++)
         // populate white occupancy bitboard
         pos->occupancies[WHITE] |= pos->bitboards[piece];
 
-    // loop over black pieces pos->pos->bitboards
     for (int piece = BP; piece <= BK; piece++)
         // populate white occupancy bitboard
         pos->occupancies[BLACK] |= pos->bitboards[piece];
 
-    // init all pos->occupancies
-    pos->occupancies[BOTH] |= pos->occupancies[WHITE];
-    pos->occupancies[BOTH] |= pos->occupancies[BLACK];
+    pos->occupancies[BOTH] = pos->occupancies[WHITE] | pos->occupancies[BLACK];
 
     pos->posKey = GeneratePosKey(pos);
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -32,6 +32,7 @@ int EvalPosition(const S_Board* pos) {
     bool stm = (pos->side == WHITE);
     int eval = nnue.output(pos->accumulator, stm);
     eval = (eval * MaterialScale(pos)) / 1024;
+    eval = eval * (200 - pos->Get50mrCounter()) / 200;
     // Clamp eval to avoid it somehow being a mate score
     eval = std::clamp(eval, -mate_score + 1, mate_score - 1);
     return eval;

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-4.0.28"
+#define NAME "Alexandria-4.0.29"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
ELO   | 2.61 +- 2.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 50336 W: 12150 L: 11772 D: 26414

Bench: 8753317