### PR TITLE
Reintroduce Razoring

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -529,6 +529,13 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, S_ThreadData* td
 				if (verification_score >= beta) return nmpScore;
 			}
 		}
+		// Razoring
+		if (depth <= 5 && eval + 256 * depth < alpha)
+		{
+			int razor_score = Quiescence<false>(alpha, beta, td, ss);
+			if (razor_score <= alpha)
+				return razor_score;
+		}
 	}
 
 moves_loop:

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-4.0.33"
+#define NAME "Alexandria-4.0.34"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
ELO   | 2.93 +- 2.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 42624 W: 10444 L: 10084 D: 22096

shorter tc test with adj off
ELO   | 5.63 +- 3.92 (95%)
SPRT  | 5.0+0.05s Threads=1 Hash=16MB
LLR   | 2.49 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 14624 W: 3664 L: 3427 D: 7533

Bench: 9577041