### PR TITLE
Small cleanups

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -369,7 +369,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, S_ThreadData* td
 	const bool in_check = pos->checkers;
 	S_MOVELIST quiet_moves;
 	quiet_moves.count = 0;
-	const int root_node = (ss->ply == 0);
+	const bool root_node = (ss->ply == 0);
 	int eval;
 	bool improving = false;
 	int Score = -MAXSCORE;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -642,7 +642,7 @@ moves_loop:
 					extension = -2;
 			}
 			// Check extension
-			else if (pos->checkers)
+			else if (in_check)
 				extension = 1;
 		}
 		// we adjust the search depth based on potential extensions

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-4.0.34"
+#define NAME "Alexandria-4.0.35"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
* use in_check variable previously declared instead of pos->checkers for check extensions
* make root_node a bool (I think it was intended as a bool, and is used as a bool)

Bench 9577041