### PR TITLE
Update continuation histories for post LMR searches

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -13,3 +13,5 @@ void UpdateCH(Search_data* sd, const Search_stack* ss, const int depth, const in
 [[nodiscard]] int GetCHScore(const Search_data* sd, const Search_stack* ss, const int move);
 [[nodiscard]] int GetHistoryScore(const S_Board* pos, const Search_data* sd, const int move, const Search_stack* ss);
 void CleanHistories(Search_data* ss);
+// Updates the continuation history score for a single move
+void updateCHScore(Search_data* sd, const Search_stack* ss, const int move, const int bonus);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -685,7 +685,15 @@ moves_loop:
 		}
 		// Search every move (excluding the first of every node) that skipped or failed LMR with full depth but a reduced window
 		if (do_full_search)
+		{
 			Score = -Negamax<false>(-alpha - 1, -alpha, newDepth, !cutNode, td, ss + 1);
+			if (depth_reduction)
+			{
+				// define the conthist bonus
+				int bonus = std::min(16 * depth * depth, 1200);
+				updateCHScore(sd, ss, move, Score > alpha ? bonus : -bonus);
+            }
+		}
 
 		// PVS Search: Search the first move and every move that is within bounds with full depth and a full window
 		if (pvNode && (moves_searched == 0 || (Score > alpha && Score < beta)))

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-4.0.35"
+#define NAME "Alexandria-5.0.1"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
ELO   | 5.49 +- 3.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 17344 W: 4218 L: 3944 D: 9182
https://chess.swehosting.se/test/3996/

Bench 8025673