### PR TITLE
Simplify full-window research condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -696,7 +696,7 @@ moves_loop:
 		}
 
 		// PVS Search: Search the first move and every move that is within bounds with full depth and a full window
-		if (pvNode && (moves_searched == 0 || (Score > alpha && Score < beta)))
+		if (pvNode && (moves_searched == 0 || Score > alpha))
 			Score = -Negamax<true>(-beta, -alpha, newDepth, false, td, ss + 1);
 
 		// take move back

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-5.0.1"
+#define NAME "Alexandria-5.0.2"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
```
ELO   | -0.02 +- 1.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
GAMES | N: 81280 W: 19767 L: 19771 D: 41742
https://chess.swehosting.se/test/4060/
```

Bench 9302937