### PR TITLE
Fix incorrect stack init 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -305,7 +305,7 @@ int AspirationWindowSearch(int prev_eval, int depth, S_ThreadData* td) {
 	// Explicitely clean stack
 	for (int i = -4; i < MAXDEPTH; i++) {
 		(ss + i)->move = NOMOVE;
-		(ss + i)->static_eval = 0;
+		(ss + i)->static_eval = score_none;
 		(ss + i)->excludedMove = NOMOVE;
 	}
 	for (int i = 0; i < MAXDEPTH; i++) {

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-5.0.2"
+#define NAME "Alexandria-5.0.3"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
ELO   | -0.01 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
GAMES | N: 25632 W: 6106 L: 6107 D: 13419
https://chess.swehosting.se/test/4114/