### PR TITLE
Extend Capthist to promotions, use Capthist to tweak LMR reduction

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -326,6 +326,8 @@ int GetPiece(const int piecetype, const int color) {
 
 // Returns the piecetype of a piece
 int GetPieceType(const int piece) {
+    if (piece == EMPTY)
+        return EMPTY;
     return PieceType[piece];
 }
 

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -41,9 +41,12 @@ void updateCHScore(Search_data* sd, const Search_stack* ss, const int move, cons
 void updateCapthistScore(const S_Board* pos, Search_data* sd, int move, int bonus) {
     // Scale bonus to fix it in a [-32768;32768] range
     int scaled_bonus = bonus - GetCapthistScore(pos, sd, move) * std::abs(bonus) / 32768;
-    int captured_piece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
+    int captured_piece = isEnpassant(move) ? PAWN : pos->PieceOn(To(move));
+    if (captured_piece == EMPTY)
+        captured_piece = PAWN;
+    int captured_piece_type = GetPieceType(captured_piece);
     // Update move score
-    sd->captHist[Piece(move)][To(move)][captured_piece] += scaled_bonus;
+    sd->captHist[Piece(move)][To(move)][captured_piece_type] += scaled_bonus;
 }
 
 // Update all histories
@@ -97,8 +100,11 @@ int GetCHScore(const Search_data* sd, const Search_stack* ss, const int move) {
 
 // Returns the history score of a move
 int GetCapthistScore(const S_Board* pos, const Search_data* sd, const int move) {
-    int captured_piece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
-    return sd->captHist[Piece(move)][To(move)][captured_piece];
+    int captured_piece = isEnpassant(move) ? PAWN : pos->PieceOn(To(move));
+    if (captured_piece == EMPTY)
+        captured_piece = PAWN;
+    int captured_piece_type = GetPieceType(captured_piece);
+    return sd->captHist[Piece(move)][To(move)][captured_piece_type];
 }
 
 int GetHistoryScore(const S_Board* pos, const Search_data* sd, const int move, const Search_stack* ss) {

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -41,12 +41,11 @@ void updateCHScore(Search_data* sd, const Search_stack* ss, const int move, cons
 void updateCapthistScore(const S_Board* pos, Search_data* sd, int move, int bonus) {
     // Scale bonus to fix it in a [-32768;32768] range
     int scaled_bonus = bonus - GetCapthistScore(pos, sd, move) * std::abs(bonus) / 32768;
-    int captured_piece = isEnpassant(move) ? PAWN : pos->PieceOn(To(move));
-    if (captured_piece == EMPTY)
-        captured_piece = PAWN;
-    int captured_piece_type = GetPieceType(captured_piece);
+    int captured_piece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
+    // If we captured an empty piece this means the move is a promotion, we can pretend we captured a pawn to use a slot of the table that would've otherwise went unused
+    if (captured_piece == EMPTY) captured_piece = PAWN;
     // Update move score
-    sd->captHist[Piece(move)][To(move)][captured_piece_type] += scaled_bonus;
+    sd->captHist[Piece(move)][To(move)][captured_piece] += scaled_bonus;
 }
 
 // Update all histories
@@ -100,15 +99,17 @@ int GetCHScore(const Search_data* sd, const Search_stack* ss, const int move) {
 
 // Returns the history score of a move
 int GetCapthistScore(const S_Board* pos, const Search_data* sd, const int move) {
-    int captured_piece = isEnpassant(move) ? PAWN : pos->PieceOn(To(move));
-    if (captured_piece == EMPTY)
-        captured_piece = PAWN;
-    int captured_piece_type = GetPieceType(captured_piece);
-    return sd->captHist[Piece(move)][To(move)][captured_piece_type];
+    int captured_piece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
+    // If we captured an empty piece this means the move is a promotion, we can pretend we captured a pawn to use a slot of the table that would've otherwise went unused
+    if (captured_piece == EMPTY) captured_piece = PAWN;
+    return sd->captHist[Piece(move)][To(move)][captured_piece];
 }
 
 int GetHistoryScore(const S_Board* pos, const Search_data* sd, const int move, const Search_stack* ss) {
-    return GetHHScore(pos, sd, move) + 2 * GetCHScore(sd, ss, move);
+    if (IsQuiet(move))
+        return GetHHScore(pos, sd, move) + 2 * GetCHScore(sd, ss, move);
+    else
+        return GetCapthistScore(pos, sd, move);
 }
 
 // Resets the history tables

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -42,7 +42,7 @@ void updateCapthistScore(const S_Board* pos, Search_data* sd, int move, int bonu
     // Scale bonus to fix it in a [-32768;32768] range
     int scaled_bonus = bonus - GetCapthistScore(pos, sd, move) * std::abs(bonus) / 32768;
     int captured_piece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
-    // If we captured an empty piece this means the move is a promotion, we can pretend we captured a pawn to use a slot of the table that would've otherwise went unused
+    // If we captured an empty piece this means the move is a promotion, we can pretend we captured a pawn to use a slot of the table that would've otherwise went unused (you can't capture pawns on the 1st/8th rank)
     if (captured_piece == EMPTY) captured_piece = PAWN;
     // Update move score
     sd->captHist[Piece(move)][To(move)][captured_piece] += scaled_bonus;
@@ -67,6 +67,7 @@ void UpdateHistories(const S_Board* pos, Search_data* sd, Search_stack* ss, cons
         }
     }
     else {
+        // increase the bestmove Capthist score
         updateCapthistScore(pos, sd, bestmove, bonus);
     }
     // For all the noisy moves that didn't cause a cut-off, even is the bestmove wasn't a noisy move, decrease the capthist score
@@ -100,7 +101,7 @@ int GetCHScore(const Search_data* sd, const Search_stack* ss, const int move) {
 // Returns the history score of a move
 int GetCapthistScore(const S_Board* pos, const Search_data* sd, const int move) {
     int captured_piece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
-    // If we captured an empty piece this means the move is a promotion, we can pretend we captured a pawn to use a slot of the table that would've otherwise went unused
+    // If we captured an empty piece this means the move is a promotion, we can pretend we captured a pawn to use a slot of the table that would've otherwise went unused (you can't capture pawns on the 1st/8th rank)
     if (captured_piece == EMPTY) captured_piece = PAWN;
     return sd->captHist[Piece(move)][To(move)][captured_piece];
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -568,14 +568,14 @@ moves_loop:
 
 		if (isQuiet && SkipQuiets) continue;
 
-		int movehistory = isQuiet ? GetHistoryScore(pos, sd, move, ss) : 0;
+		int movehistory = isQuiet ? GetHistoryScore(pos, sd, move, ss) : GetCapthistScore(pos, sd, move);
 
 		// if the move isn't a quiet move we update the quiet moves list and counter
 		if (isQuiet) {
 			quiet_moves.moves[quiet_moves.count].move = move;
 			quiet_moves.count++;
 		}
-		else if(IsCapture(move)){
+		else {
 			noisy_moves.moves[noisy_moves.count].move = move;
 			noisy_moves.count++;
 		}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -764,7 +764,7 @@ moves_loop:
 	// Set the TT flag based on whether the BestScore is better than beta and if it's not based on if we changed alpha or not
 	int flag = BestScore >= beta ? HFLOWER : (alpha != old_alpha) ? HFEXACT : HFUPPER;
 
-	if (!excludedMove) StoreHashEntry(pos->posKey, MoveToTT(bestmove), ScoreToTT(BestScore, ss->ply), ss->static_eval, flag, depth, pvNode,ttPv);
+	if (!excludedMove) StoreHashEntry(pos->posKey, MoveToTT(bestmove), ScoreToTT(BestScore, ss->ply), ss->static_eval, flag, depth, pvNode, ttPv);
 	// return best score
 	return BestScore;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -568,7 +568,7 @@ moves_loop:
 
 		if (isQuiet && SkipQuiets) continue;
 
-		int movehistory = isQuiet ? GetHistoryScore(pos, sd, move, ss) : GetCapthistScore(pos, sd, move);
+		int movehistory = GetHistoryScore(pos, sd, move, ss);
 
 		// if the move isn't a quiet move we update the quiet moves list and counter
 		if (isQuiet) {

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-5.0.7"
+#define NAME "Alexandria-5.0.8"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
ELO   | 2.80 +- 2.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 44640 W: 10812 L: 10452 D: 23376
https://chess.swehosting.se/test/4224/
Bench: 9065622