### PR TITLE
Do more history updates if eval <= alpha

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -753,7 +753,7 @@ moves_loop:
 							sd->CounterMoves[From((ss - 1)->move)][To((ss - 1)->move)] = move;
 					}
                     // Update the history heuristics based on the new best move
-					UpdateHistories(pos, sd, ss, depth, bestmove, &quiet_moves, &noisy_moves);
+					UpdateHistories(pos, sd, ss, depth + (eval <= alpha), bestmove, &quiet_moves, &noisy_moves);
 
 					// node (move) fails high
 					break;

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-5.0.10"
+#define NAME "Alexandria-5.0.11"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
Idea from black marlin (and boychesser). 
```
ELO   | 5.52 +- 3.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 17312 W: 4302 L: 4027 D: 8983
https://chess.swehosting.se/test/4397/
```
Bench 8547310