### PR TITLE
Use a less deranged replacement scheme

### DIFF
--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -39,7 +39,7 @@ void StoreHashEntry(const ZobristKey key, const int16_t move, int score, int16_t
         tte->move = move;
 
     // Overwrite less valuable entries (cheapest checks first)
-    if (flags == HFEXACT || static_cast<TTKey>(key) != tte->tt_key || depth + 11 + 2 * pv > tte->depth) {
+    if (flags == HFEXACT || static_cast<TTKey>(key) != tte->tt_key || depth + 5 + 2 * pv > tte->depth) {
         tte->tt_key = static_cast<TTKey>(key);
         tte->wasPv_flags = static_cast<uint8_t>(flags + (wasPv << 2));
         tte->score = static_cast<int16_t>(score);


### PR DESCRIPTION
ELO   | 1.16 +- 2.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
GAMES | N: 30576 W: 7484 L: 7382 D: 15710
Bench: 9037635