### PR TITLE
Add futility pruning to qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -875,7 +875,7 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 			&& BoardHasNonPawns(pos, pos->side) 
 			&& !isPromo(move) 
 			&& !isEnpassant(move)) {
-				int futilityBase = ss->static_eval + 256;
+				int futilityBase = ss->static_eval + 192;
 				if (futilityBase <= alpha && !SEE(pos, move, 1)) {
 					BestScore = std::max(futilityBase, BestScore);
 					continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -868,6 +868,19 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 			break;
 		}
 		ss->move = move;
+
+		// Futility pruning. If static eval is far below alpha, only search moves that win material.
+		if (BestScore > -mate_found 
+			&& !in_check 
+			&& BoardHasNonPawns(pos, pos->side) 
+			&& !isPromo(move) 
+			&& !isEnpassant(move)) {
+				int futilityBase = ss->static_eval + 256;
+				if (futilityBase <= alpha && !SEE(pos, move, 1)) {
+					BestScore = std::max(futilityBase, BestScore);
+					continue;
+				}
+			}
 		MakeMove(move, pos);
 		// increment nodes count
 		info->nodes++;

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-5.0.20"
+#define NAME "Alexandria-5.0.21"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
ELO   | 1.98 +- 1.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 88256 W: 21557 L: 21054 D: 45645
https://chess.swehosting.se/test/4663/

Bench 8913775