### PR TITLE
Fix countermoves usage in move ordering

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -217,7 +217,7 @@ static inline void score_moves(S_Board* pos, Search_data* sd, Search_stack* ss, 
             continue;
         }
         // After the killer moves try the Counter moves
-        else if (move == sd->CounterMoves[From(ss->move)][To(ss->move)]) {
+        else if (move == sd->CounterMoves[From((ss - 1)->move)][To((ss - 1)->move)]) {
             move_list->moves[i].score = counterMoveScore;
             continue;
         }

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-5.0.21"
+#define NAME "Alexandria-5.0.22"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
ELO   | 3.71 +- 2.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 29888 W: 7405 L: 7086 D: 15397
https://chess.swehosting.se/test/4704/

Bench: 7799933