### PR TITLE
Rebalance and simplify LMR formula

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -244,8 +244,8 @@ void InitReductions() {
 
     for (int i = 1; i < MAXDEPTH; i++) {
         for (int j = 1; j < MAXDEPTH; j++) {
-            reductions[0][i][j] = log(i) * log(j) / 2.00;
-            reductions[1][i][j] = log(i) * log(j) / 2.00;
+            reductions[0][i][j] = +0.00 + log(i) * log(j) / 2.00;
+            reductions[1][i][j] = +1.00 + log(i) * log(j) / 2.00;
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -244,7 +244,7 @@ void InitReductions() {
 
     for (int i = 1; i < MAXDEPTH; i++) {
         for (int j = 1; j < MAXDEPTH; j++) {
-            reductions[0][i][j] = -0.25 + log(i) * log(j) / 2.00;
+            reductions[0][i][j] = -0.50 + log(i) * log(j) / 2.00;
             reductions[1][i][j] = +1.00 + log(i) * log(j) / 2.00;
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -244,7 +244,7 @@ void InitReductions() {
 
     for (int i = 1; i < MAXDEPTH; i++) {
         for (int j = 1; j < MAXDEPTH; j++) {
-            reductions[0][i][j] = -0.50 + log(i) * log(j) / 2.00;
+            reductions[0][i][j] = -0.25 + log(i) * log(j) / 2.25;
             reductions[1][i][j] = +1.00 + log(i) * log(j) / 2.00;
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -244,7 +244,7 @@ void InitReductions() {
 
     for (int i = 1; i < MAXDEPTH; i++) {
         for (int j = 1; j < MAXDEPTH; j++) {
-            reductions[0][i][j] = +0.00 + log(i) * log(j) / 2.00;
+            reductions[0][i][j] = -0.25 + log(i) * log(j) / 2.00;
             reductions[1][i][j] = +1.00 + log(i) * log(j) / 2.00;
         }
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -667,28 +667,26 @@ moves_loop:
         uint64_t nodesBeforeSearch = info->nodes;
         bool doFullSearch = false;
         // Conditions to consider LMR. Calculate how much we should reduce the search depth.
-        if (movesSearched >= 2 + 2 * pvNode && depth >= 3) {
-            if (isQuiet || !ttPv) {
+        if (movesSearched >= 2 + 2 * pvNode && depth >= 3 && (isQuiet || !ttPv)) {
 
-                // Get base reduction value
-                depthReduction = reductions[isQuiet][depth][movesSearched];
+            // Get base reduction value
+            depthReduction = reductions[isQuiet][depth][movesSearched];
 
-                // Reduce more if we aren't in a pv node
-                depthReduction += !ttPv;
+            // Reduce more if we aren't in a pv node
+            depthReduction += !ttPv;
 
-                // Fuck
-                depthReduction += 2 * cutNode;
+            // Fuck
+            depthReduction += 2 * cutNode;
 
-                // Reduce less if we are improving
-                depthReduction -= improving;
+            // Reduce less if we are improving
+            depthReduction -= improving;
 
-                // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
-                depthReduction -= std::clamp(moveHistory / 16384, -2, 2);
+            // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
+            depthReduction -= std::clamp(moveHistory / 16384, -2, 2);
 
-                // Decrease the reduction for moves that give check
-                if (pos->checkers)
-                    depthReduction -= 1;
-            }
+            // Decrease the reduction for moves that give check
+            if (pos->checkers)
+                depthReduction -= 1;
 
             // adjust the reduction so that we can't drop into Qsearch and to prevent extensions
             depthReduction = std::clamp(depthReduction, 0, newDepth - 1);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -668,10 +668,10 @@ moves_loop:
         bool doFullSearch = false;
         // Conditions to consider LMR. Calculate how much we should reduce the search depth.
         if (movesSearched >= 2 + 2 * pvNode && depth >= 3) {
-            if (isQuiet) {
+            if (isQuiet || !ttPv) {
 
                 // Get base reduction value
-                depthReduction = reductions[true][depth][movesSearched];
+                depthReduction = reductions[isQuiet][depth][movesSearched];
 
                 // Reduce more if we aren't in a pv node
                 depthReduction += !ttPv;
@@ -689,18 +689,7 @@ moves_loop:
                 if (pos->checkers)
                     depthReduction -= 1;
             }
-            else if (!ttPv) {
 
-                // Get base reduction value
-                depthReduction = reductions[false][depth][movesSearched];
-
-                // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
-                depthReduction -= std::clamp(moveHistory / 16384, -2, 2);
-
-                // Decrease the reduction for moves that give check
-                if (pos->checkers)
-                    depthReduction -= 1;
-            }
             // adjust the reduction so that we can't drop into Qsearch and to prevent extensions
             depthReduction = std::clamp(depthReduction, 0, newDepth - 1);
             // search current move with reduced depth:

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -595,9 +595,9 @@ moves_loop:
 
             // Futility pruning: if the static eval is so low that even after adding a bonus we are still under alpha we can stop trying quiet moves
             if (   !inCheck
-                &&  lmrDepth < 12
+                &&  lmrDepth < 11
                 &&  isQuiet
-                &&  ss->staticEval + 100 + 150 * lmrDepth <= alpha) {
+                &&  ss->staticEval + 250 + 150 * lmrDepth <= alpha) {
                 SkipQuiets = true;
                 continue;
             }
@@ -673,14 +673,14 @@ moves_loop:
                 // Get base reduction value
                 depthReduction = reductions[true][depth][movesSearched];
 
-                // Reduce more if we aren't improving
-                depthReduction += !improving;
-
                 // Reduce more if we aren't in a pv node
                 depthReduction += !ttPv;
 
                 // Fuck
                 depthReduction += 2 * cutNode;
+
+                // Reduce less if we are improving
+                depthReduction -= improving;
 
                 // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
                 depthReduction -= std::clamp(moveHistory / 16384, -2, 2);


### PR DESCRIPTION
Also requires adjustments to lmrDepth coefficients.

ELO   | 0.48 +- 1.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.76 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 76512 W: 18331 L: 18225 D: 39956
https://chess.swehosting.se/test/5037/

However, it passes [-3, 1] with a 4.66 LLR.

Bench: 8236697