### PR TITLE
Simplify depth guard for lmp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -592,7 +592,6 @@ moves_loop:
             // Movecount pruning: if we searched enough moves and we are not in check we skip the rest
             if (   !pvNode
                 && !inCheck
-                &&  depth < 9
                 &&  isQuiet
                 &&  movesSearched > lmp_margin[depth][improving]) {
                 SkipQuiets = true;

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-5.1.4"
+#define NAME "Alexandria-5.1.5"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
this was already basically non functional, the first depth at which the guard did something was 9, that meant 84 moves for a node where improving was true and 42 for a node where it was false.
Passed STC non regr 
```
Elo   | 1.47 +- 3.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 22930 W: 5622 L: 5525 D: 11783
Penta | [111, 2526, 6087, 2637, 104]
```
Got tired of waiting for LTC non regr
```
Elo   | 2.24 +- 4.05 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.46 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 13048 W: 3068 L: 2984 D: 6996
Penta | [21, 1358, 3681, 1444, 20]
```