### PR TITLE
Improve 3fold detection

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -71,6 +71,7 @@ void ResetBoard(S_Board* pos) {
         pos->pieces[index] = EMPTY;
     }
     pos->castleperm = 0; 
+    pos->plyFromNull = 0;
 }
 
 void ResetInfo(S_SearchINFO* info) {

--- a/src/board.h
+++ b/src/board.h
@@ -73,6 +73,7 @@ struct S_Undo {
     int enPas = 0;
     int fiftyMove = 0;
     bool checkers = false;
+    int plyFromNull = 0;
 }; // stores a move and the state of the game before that move is made
 // for rollback purposes
 
@@ -88,6 +89,7 @@ public:
     int enPas = no_sq; // if enpassant is possible and in which square
     int fiftyMove = 0; // Counter for the 50 moves rule
     int hisPly = 0; // total number of halfmoves
+    int plyFromNull = 0;
     int castleperm = 0;
     // unique  hashkey  that encodes a board position
     ZobristKey posKey = 0ULL;

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -71,6 +71,8 @@ void MakeMove(const int move, S_Board* pos) {
     pos->history[pos->hisPly].enPas = pos->enPas;
     pos->history[pos->hisPly].castlePerm = pos->castleperm;
     pos->history[pos->hisPly].checkers = pos->checkers;
+    pos->history[pos->hisPly].plyFromNull = pos->plyFromNull;
+
     // Store position key in the array of searched position
     pos->played_positions.emplace_back(pos->posKey);
 
@@ -88,7 +90,7 @@ void MakeMove(const int move, S_Board* pos) {
     const bool promotion = isPromo(move);
     // increment fifty move rule counter
     pos->fiftyMove++;
-
+    pos->plyFromNull++;
     const int NORTH = pos->side == WHITE ? 8 : -8;
 
     // if a pawn was moved reset the 50 move rule counter
@@ -181,6 +183,7 @@ void UnmakeMove(const int move, S_Board* pos) {
     pos->fiftyMove = pos->history[pos->hisPly].fiftyMove;
     pos->castleperm = pos->history[pos->hisPly].castlePerm;
     pos->checkers = pos->history[pos->hisPly].checkers;
+    pos->plyFromNull = pos->history[pos->hisPly].plyFromNull;
 
     // parse move
     const int sourceSquare = From(move);
@@ -264,11 +267,13 @@ void MakeNullMove(S_Board* pos) {
     pos->history[pos->hisPly].enPas = pos->enPas;
     pos->history[pos->hisPly].castlePerm = pos->castleperm;
     pos->history[pos->hisPly].checkers = pos->checkers;
+    pos->history[pos->hisPly].plyFromNull = pos->plyFromNull;
     // Store position key in the array of searched position
     pos->played_positions.emplace_back(pos->posKey);
 
     pos->hisPly++;
     pos->fiftyMove++;
+    pos->plyFromNull=0;
 
     // Reset EP square
     if (GetEpSquare(pos) != no_sq)
@@ -288,6 +293,7 @@ void TakeNullMove(S_Board* pos) {
     pos->fiftyMove = pos->history[pos->hisPly].fiftyMove;
     pos->enPas = pos->history[pos->hisPly].enPas;
     pos->checkers = pos->history[pos->hisPly].checkers;
+    pos->plyFromNull = pos->history[pos->hisPly].plyFromNull;
 
     pos->ChangeSide();
     pos->posKey = pos->played_positions.back();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -20,10 +20,11 @@
 static bool IsRepetition(const S_Board* pos, const bool pvNode) {
     assert(pos->hisPly >= pos->fiftyMove);
     int counter = 1;
-    // How many moves back should we look at most
+    // How many moves back should we look at most, aka our distance to the last irreversible move
     int distance = std::min(pos->Get50mrCounter(), pos->plyFromNull);
-    int startingPoint = std::max(static_cast<int>(pos->played_positions.size()) - distance, 0);
-    // we only need to check for repetition the moves since the last 50mr reset
+    // Get the point our search should start from
+    int startingPoint = std::max<int>(pos->played_positions.size() - distance, 0);
+    // Scan forwards from our starting point to the current position
     for (int index = startingPoint; index < static_cast<int>(pos->played_positions.size()); index++)
         // if we found the same position hashkey as the current position
         if (pos->played_positions[index] == pos->posKey) {
@@ -32,7 +33,6 @@ static bool IsRepetition(const S_Board* pos, const bool pvNode) {
             if (counter >= 2 + pvNode)
                 return true;
         }
-
     return false;
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -23,11 +23,11 @@ static bool IsRepetition(const S_Board* pos, const bool pvNode) {
     // How many moves back should we look at most, aka our distance to the last irreversible move
     int distance = std::min(pos->Get50mrCounter(), pos->plyFromNull);
     // Get the point our search should start from
-    int startingPoint = std::max<int>(pos->played_positions.size() - distance, 0);
-    // Scan forwards from our starting point to the current position
-    for (int index = startingPoint; index < static_cast<int>(pos->played_positions.size()); index++)
+    int startingPoint = pos->played_positions.size();
+    // Scan backwards from our starting point to the current position
+    for (int index = 4; index <= distance; index += 2)
         // if we found the same position hashkey as the current position
-        if (pos->played_positions[index] == pos->posKey) {
+        if (pos->played_positions[startingPoint - index] == pos->posKey) {
             // we found a repetition
             counter++;
             if (counter >= 2 + pvNode)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -20,11 +20,11 @@
 static bool IsRepetition(const S_Board* pos, const bool pvNode) {
     assert(pos->hisPly >= pos->fiftyMove);
     int counter = 1;
-
+    // How many moves back should we look at most
+    int distance = std::min(pos->Get50mrCounter(), pos->plyFromNull);
+    int startingPoint = std::max(static_cast<int>(pos->played_positions.size()) - distance, 0);
     // we only need to check for repetition the moves since the last 50mr reset
-    for (int index = std::max(static_cast<int>(pos->played_positions.size()) - pos->Get50mrCounter(), 0);
-        index < static_cast<int>(pos->played_positions.size()); index++)
-
+    for (int index = startingPoint; index < static_cast<int>(pos->played_positions.size()); index++)
         // if we found the same position hashkey as the current position
         if (pos->played_positions[index] == pos->posKey) {
             // we found a repetition

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -24,7 +24,7 @@ static bool IsRepetition(const S_Board* pos, const bool pvNode) {
     int distance = std::min(pos->Get50mrCounter(), pos->plyFromNull);
     // Get the point our search should start from
     int startingPoint = pos->played_positions.size();
-    // Scan backwards from our starting point to the current position
+    // Scan backwards from the first position where a repetition is possible (4 half moves ago) for at most distance steps
     for (int index = 4; index <= distance; index += 2)
         // if we found the same position hashkey as the current position
         if (pos->played_positions[startingPoint - index] == pos->posKey) {

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-5.1.8"
+#define NAME "Alexandria-5.1.9"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
Swaps out old 3fold detection code for a version that is more efficient, better explained, and less awful to look at.
Improvements include not looking further than the last null move, since that too is irreversible, scanning backwards instead of forwards since repetitions are more likely to have happened in recent plies and only checking positions with a matching side to move.
Bench: 6645600