### PR TITLE
Align TM code for X+Y to the one used for cyclic time controls

### DIFF
--- a/src/time_manager.cpp
+++ b/src/time_manager.cpp
@@ -20,7 +20,7 @@ void Optimum(S_SearchINFO* info, int time, int inc) {
     else if (info->timeset && info->movestogo != -1) {
         // Divide the time you have left for how many moves you have to play
         const auto basetime = time / info->movestogo;
-        // Never use more than 80% of the total time left for a single move
+        // Never use more than 75% of the total time left for a single move
         const auto maxtimeBound = 0.75 * time;
         // optime is the time we use to stop if we just cleared a depth
         const auto optime = std::min(0.7 * basetime, maxtimeBound);
@@ -33,10 +33,12 @@ void Optimum(S_SearchINFO* info, int time, int inc) {
     // else if we recieved wtime/btime we calculate an over and upper bound for the time usage based on fixed coefficients
     else if (info->timeset) {
         int basetime = time / 20 + inc * 3 / 4;
+        // Never use more than 75% of the total time left for a single move
+        const auto maxtimeBound = 0.75 * time;
         // optime is the time we use to stop if we just cleared a depth
-        int optime = basetime * 0.6;
-        // maxtime is the absolute maximum time we can spend on a search
-        int maxtime = std::min(time, basetime * 2);
+        const auto optime = std::min(0.7 * basetime, maxtimeBound);
+        // maxtime is the absolute maximum time we can spend on a search (unless it is bigger than the bound)
+        const auto maxtime = std::min(3.0 * basetime, maxtimeBound);
         info->stoptimeMax = info->starttime + maxtime;
         info->stoptimeBaseOpt = optime;
         info->stoptimeOpt = info->starttime + info->stoptimeBaseOpt;

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-5.1.14"
+#define NAME "Alexandria-5.1.15"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
I have no idea why we were using that awful tm code for regular time controls
STC:
```
Elo   | 12.26 +- 6.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 5244 W: 1363 L: 1178 D: 2703
Penta | [20, 506, 1386, 689, 21]
```
Note: at STC this patch only exacerbate the existing time out issue, with the entire test having 13 time outs (10 from the dev version).

LTC:
```
Elo   | 4.52 +- 3.83 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14612 W: 3473 L: 3283 D: 7856
Penta | [16, 1499, 4094, 1673, 24]
```
Note: no time out noticed at LTC.