### PR TITLE
Optimise NNUE accumulator updates

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -103,6 +103,8 @@ public:
     S_Undo    history[1024];
     // Stores the zobrist keys of all the positions played in the game + the current search instance, used for 3-fold
     std::vector<ZobristKey> played_positions = {};
+    std::vector<std::pair<std::size_t, std::size_t>> NNUEAdd = {};
+    std::vector<std::pair<std::size_t, std::size_t>> NNUESub = {};
     Bitboard pinHV = 0ULL;
     Bitboard pinD = 0ULL;
 

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -197,7 +197,7 @@ void MakeMove(const int move, S_Board* pos) {
     const int sourceSquare = From(move);
     const int targetSquare = To(move);
     const int piece = Piece(move);
-    const int promotedPiece = GetPiece(getPromotedPiecetype(move),pos->side);
+    const int promotedPiece = GetPiece(getPromotedPiecetype(move), pos->side);
     // parse move flag
     const bool capture = IsCapture(move);
     const bool doublePush = isDP(move);

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -28,13 +28,13 @@ void AddPiece(const int piece, const int to, S_Board* pos) {
 
 // Remove a piece from a square while also deactivating the nnue weights tied to the piece
 void ClearPieceNNUE(const int piece, const int sq, S_Board* pos) {
-    nnue.clear(pos->AccumulatorTop(), piece, sq);
+    pos->NNUESub.emplace_back(nnue.GetIndex(piece, sq));
     ClearPiece(piece, sq, pos);
 }
 
 // Add a piece to a square while also activating the nnue weights tied to the piece
 void AddPieceNNUE(const int piece, const int to, S_Board* pos) {
-    nnue.add(pos->AccumulatorTop(), piece, to);
+    pos->NNUEAdd.emplace_back(nnue.GetIndex(piece, to));
     AddPiece(piece, to, pos);
 }
 
@@ -46,7 +46,8 @@ void MovePiece(const int piece, const int from, const int to, S_Board* pos) {
 
 // Move a piece from square to to square from
 void MovePieceNNUE(const int piece, const int from, const int to, S_Board* pos) {
-    nnue.move(pos->AccumulatorTop(), piece, from, to);
+    pos->NNUEAdd.emplace_back(nnue.GetIndex(piece, to));
+    pos->NNUESub.emplace_back(nnue.GetIndex(piece, from));
     MovePiece(piece, from, to, pos);
 }
 
@@ -279,6 +280,8 @@ void MakeMove(const int move, S_Board* pos) {
         }
     }
     UpdateCastlingPerms(pos, sourceSquare, targetSquare);
+
+    nnue.update(pos->AccumulatorTop(), pos->NNUEAdd, pos->NNUESub);
 
     // change side
     pos->ChangeSide();

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -85,30 +85,74 @@ void NNUE::add(NNUE::accumulator& board_accumulator, const int piece, const int 
     }
 }
 
-void NNUE::clear(NNUE::accumulator& board_accumulator, const int piece, const int from) {
-    auto [whiteIdx, blackIdx] = GetIndex(piece, from);
-    auto whiteSub = &net.featureWeights[whiteIdx * HIDDEN_SIZE];
-    auto blackSub = &net.featureWeights[blackIdx * HIDDEN_SIZE];
-    for (int i = 0; i < HIDDEN_SIZE; i++) {
-        board_accumulator[0][i] -= whiteSub[i];
+void NNUE::update(NNUE::accumulator& board_accumulator, std::vector<std::pair<std::size_t, std::size_t>> NNUEAdd, std::vector<std::pair<std::size_t, std::size_t>> NNUESub) {
+    int adds = NNUEAdd.size();
+    int subs = NNUESub.size();
+    // Quiets
+    if (adds == 1 && subs == 1) {
+        auto [whiteAddIdx, blackAddIdx] = NNUEAdd.back();
+        NNUEAdd = {};
+        auto [whiteSubIdx, blackSubIdx] = NNUESub.back();
+        NNUESub = {};
+        addSub(board_accumulator, whiteAddIdx, blackAddIdx, whiteSubIdx, blackSubIdx);
     }
-    for (int i = 0; i < HIDDEN_SIZE; i++) {
-        board_accumulator[1][i] -= blackSub[i];
+    // Captures
+    else if (adds == 1 && subs == 2) {
+        auto [whiteAddIdx, blackAddIdx] = NNUEAdd.back();
+        NNUEAdd = {};
+        auto [whiteSubIdx1, blackSubIdx1] = NNUESub.back();
+        NNUESub.pop_back();
+        auto [whiteSubIdx2, blackSubIdx2] = NNUESub.back();
+        NNUESub = {};
+        addSubSub(board_accumulator, whiteAddIdx, blackAddIdx, whiteSubIdx1, blackSubIdx1, whiteSubIdx2, blackSubIdx2);
+    }
+    // Castling
+    else {
+        auto [whiteAddIdx1, blackAddIdx1] = NNUEAdd.back();
+        NNUEAdd.pop_back();
+        auto [whiteAddIdx2, blackAddIdx2] = NNUEAdd.back();
+        NNUEAdd = {};
+        auto [whiteSubIdx1, blackSubIdx1] = NNUESub.back();
+        NNUESub.pop_back();
+        auto [whiteSubIdx2, blackSubIdx2] = NNUESub.back();
+        NNUESub = {};
+        addSub(board_accumulator, whiteAddIdx1, blackAddIdx1, whiteSubIdx1, blackSubIdx1);
+        addSub(board_accumulator, whiteAddIdx2, blackAddIdx2, whiteSubIdx2, blackSubIdx2);
     }
 }
 
-void NNUE::move(NNUE::accumulator& board_accumulator, const int piece, const int from, const int to) {
-    auto [whiteIdxFrom, blackIdxFrom] = GetIndex(piece, from);
-    auto [whiteIdxTo, blackIdxTo] = GetIndex(piece, to);
-    auto whiteSub = &net.featureWeights[whiteIdxFrom * HIDDEN_SIZE];
-    auto whiteAdd = &net.featureWeights[whiteIdxTo * HIDDEN_SIZE];
+void NNUE::addSub(NNUE::accumulator& board_accumulator, std::size_t whiteAddIdx, std::size_t blackAddIdx, std::size_t whiteSubIdx, std::size_t blackSubIdx) {
+    auto whiteAdd = &net.featureWeights[whiteAddIdx * HIDDEN_SIZE];
+    auto whiteSub = &net.featureWeights[whiteSubIdx * HIDDEN_SIZE];
     for (int i = 0; i < HIDDEN_SIZE; i++) {
         board_accumulator[0][i] = board_accumulator[0][i] - whiteSub[i] + whiteAdd[i];
     }
-    auto blackSub = &net.featureWeights[blackIdxFrom * HIDDEN_SIZE];
-    auto blackAdd = &net.featureWeights[blackIdxTo * HIDDEN_SIZE];
+    auto blackAdd = &net.featureWeights[blackAddIdx * HIDDEN_SIZE];
+    auto blackSub = &net.featureWeights[blackSubIdx * HIDDEN_SIZE];
     for (int i = 0; i < HIDDEN_SIZE; i++) {
         board_accumulator[1][i] = board_accumulator[1][i] - blackSub[i] + blackAdd[i];
+    }
+}
+
+void NNUE::addSubSub(NNUE::accumulator& board_accumulator, 
+                     std::size_t whiteAddIdx,
+                     std::size_t blackAddIdx,
+                     std::size_t whiteSubIdx1,
+                     std::size_t blackSubIdx1,
+                     std::size_t whiteSubIdx2,
+                     std::size_t blackSubIdx2) {
+
+    auto whiteAdd = &net.featureWeights[whiteAddIdx * HIDDEN_SIZE];
+    auto whiteSub1 = &net.featureWeights[whiteSubIdx1 * HIDDEN_SIZE];
+    auto whiteSub2 = &net.featureWeights[whiteSubIdx2 * HIDDEN_SIZE];
+    for (int i = 0; i < HIDDEN_SIZE; i++) {
+        board_accumulator[0][i] = board_accumulator[0][i] - whiteSub1[i] - whiteSub2[i] + whiteAdd[i];
+    }
+    auto blackAdd = &net.featureWeights[blackAddIdx * HIDDEN_SIZE];
+    auto blackSub1 = &net.featureWeights[blackSubIdx1 * HIDDEN_SIZE];
+    auto blackSub2 = &net.featureWeights[blackSubIdx2 * HIDDEN_SIZE];
+    for (int i = 0; i < HIDDEN_SIZE; i++) {
+        board_accumulator[1][i] = board_accumulator[1][i] - blackSub1[i] - blackSub2[i] + blackAdd[i];
     }
 }
 
@@ -139,8 +183,7 @@ std::pair<std::size_t, std::size_t> NNUE::GetIndex(const int piece, const int sq
     constexpr std::size_t COLOR_STRIDE = 64 * 6;
     constexpr std::size_t PIECE_STRIDE = 64;
     int piecetype = GetPieceType(piece);
-    int color = piece / 6;
-    // return square + piecetype * 64 + (Color[piece] == BLACK) * 64 * 6;
+    int color = Color[piece];
     std::size_t whiteIdx = color * COLOR_STRIDE + piecetype * PIECE_STRIDE + (square ^ 0b111'000);
     std::size_t blackIdx = (1 ^ color) * COLOR_STRIDE + piecetype * PIECE_STRIDE + square;
     return {whiteIdx, blackIdx};

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -85,7 +85,7 @@ void NNUE::add(NNUE::accumulator& board_accumulator, const int piece, const int 
     }
 }
 
-void NNUE::update(NNUE::accumulator& board_accumulator, std::vector<std::pair<std::size_t, std::size_t>> NNUEAdd, std::vector<std::pair<std::size_t, std::size_t>> NNUESub) {
+void NNUE::update(NNUE::accumulator& board_accumulator, std::vector<std::pair<std::size_t, std::size_t>>& NNUEAdd, std::vector<std::pair<std::size_t, std::size_t>>& NNUESub) {
     int adds = NNUEAdd.size();
     int subs = NNUESub.size();
     // Quiets

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <array>
+#include <vector>
 
 constexpr int INPUT_WEIGHTS = 768;
 constexpr int HIDDEN_SIZE = 1024;
@@ -21,8 +22,9 @@ public:
 
     void init(const char* file);
     void add(NNUE::accumulator& board_accumulator, const int piece, const int to);
-    void clear(NNUE::accumulator& board_accumulator, const int piece, const int from);
-    void move(NNUE::accumulator& board_accumulator, const int piece, const int from, const int to);
+    void update(NNUE::accumulator& board_accumulator, std::vector<std::pair<std::size_t, std::size_t>> NNUEAdd, std::vector<std::pair<std::size_t, std::size_t>> NNUESub);
+    void addSub(NNUE::accumulator& board_accumulator, std::size_t whiteAddIdx, std::size_t blackAddIdx, std::size_t whiteSubIdx, std::size_t blackSubIdx);
+    void addSubSub(NNUE::accumulator& board_accumulator, std::size_t whiteAddIdx, std::size_t blackAddIdx, std::size_t whiteSubIdx1, std::size_t blackSubIdx1, std::size_t whiteSubIdx2, std::size_t blackSubIdx2);
     [[nodiscard]] int32_t SCReLU(int16_t x);
     [[nodiscard]] int32_t output(const NNUE::accumulator& board_accumulator, const bool whiteToMove);
     [[nodiscard]] std::pair<std::size_t, std::size_t> GetIndex(const int piece, const int square);

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -22,7 +22,7 @@ public:
 
     void init(const char* file);
     void add(NNUE::accumulator& board_accumulator, const int piece, const int to);
-    void update(NNUE::accumulator& board_accumulator, std::vector<std::pair<std::size_t, std::size_t>> NNUEAdd, std::vector<std::pair<std::size_t, std::size_t>> NNUESub);
+    void update(NNUE::accumulator& board_accumulator, std::vector<std::pair<std::size_t, std::size_t>>& NNUEAdd, std::vector<std::pair<std::size_t, std::size_t>>& NNUESub);
     void addSub(NNUE::accumulator& board_accumulator, std::size_t whiteAddIdx, std::size_t blackAddIdx, std::size_t whiteSubIdx, std::size_t blackSubIdx);
     void addSubSub(NNUE::accumulator& board_accumulator, std::size_t whiteAddIdx, std::size_t blackAddIdx, std::size_t whiteSubIdx1, std::size_t blackSubIdx1, std::size_t whiteSubIdx2, std::size_t blackSubIdx2);
     [[nodiscard]] int32_t SCReLU(int16_t x);

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-5.1.16"
+#define NAME "Alexandria-5.1.17"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
Do all updates at once rather than each time `AddPieceNNUE`, `MovePieceNNUE` or `ClearPieceNNUE` is called.

ELO   | 8.19 +- 4.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 10816 W: 2730 L: 2475 D: 5611
https://chess.swehosting.se/test/5287/

Bench: 7592451