### PR TITLE
Clear killers and excluded move properly

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -377,6 +377,11 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, S_ThreadData* td
     if (depth >= 4 && ttFlag == HFNONE)
         depth--;
 
+    // clean killers and excluded move for the next ply
+    (ss + 1)->excludedMove = NOMOVE;
+    (ss + 1)->searchKillers[0] = NOMOVE;
+    (ss + 1)->searchKillers[1] = NOMOVE;
+
     // If we are in check or searching a singular extension we avoid pruning before the move loop
     if (inCheck || excludedMove) {
         ss->staticEval = eval = score_none;
@@ -426,11 +431,6 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, S_ThreadData* td
     }
     else
         improving = true;
-    
-    // clean killers and excluded move for the next ply
-    (ss + 1)->excludedMove = NOMOVE;
-    (ss + 1)->searchKillers[0] = NOMOVE;
-    (ss + 1)->searchKillers[1] = NOMOVE;
 
     if (!pvNode) {
         // Reverse futility pruning


### PR DESCRIPTION
```
ELO   | 1.08 +- 2.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.02 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 38272 W: 9241 L: 9122 D: 19909
https://chess.swehosting.se/test/5312/
```

Passed nonreg:
```
$ python3 sprt.py --wins 9241 --losses 9122 --draws 19909 --elo0 -3 --elo1 1
ELO: 1.08 +- 2.41 [-1.33, 3.49]
LLR: 3.49 [-3.0, 1.0] (-2.94, 2.94)
H1 Accepted
```

Bench 7513941