### PR TITLE
Do negative extensions on expected cut nodes 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -579,9 +579,14 @@ moves_loop:
                 else if (singularBeta >= beta)
                     return singularBeta;
 
-                // If we didn't successfully extend and our eval is above beta reduce the search depth
+                // If we didn't successfully extend and our TT score is above beta reduce the search depth
                 else if (ttScore >= beta)
                     extension = -2;
+
+                // If we are expecting a fail-high both based on node type and based on TT bound
+                // but our TT move is not singular and our TT score is failing low, reduce the search depth
+                else if (ttScore <= alpha && cutNode)
+                    extension = -1;
             }
         }
         // we adjust the search depth based on potential extensions

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -583,7 +583,7 @@ moves_loop:
                 else if (ttScore >= beta)
                     extension = -2;
 
-                // If we are expecting a fail-high both based on node type and based on TT bound
+                // If we are expecting a fail-high both based on search states from previous plies and based on TT bound
                 // but our TT move is not singular and our TT score is failing low, reduce the search depth
                 else if (ttScore <= alpha && cutNode)
                     extension = -1;

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-5.1.20"
+#define NAME "Alexandria-5.1.21"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
Same logic as https://github.com/official-stockfish/Stockfish/commit/e551964ef63e4e4af4bb6132538b98fad4a51afe

```
ELO   | 3.59 +- 2.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 31264 W: 7653 L: 7330 D: 16281
https://chess.swehosting.se/test/5349/
```