### PR TITLE
Tweak parameters for reverse futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -423,8 +423,8 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, S_ThreadData* td
 
     if (!pvNode) {
         // Reverse futility pruning
-        if (   depth < 9
-            && eval - 66 * (depth - improving) >= beta
+        if (   depth < 10
+            && eval - 81 * (depth - improving) >= beta
             && abs(eval) < mate_found)
             return eval;
 

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-6.0"
+#define NAME "Alexandria-6.0.1"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
ELO   | 2.50 +- 2.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 53408 W: 12670 L: 12286 D: 28452
https://chess.swehosting.se/test/5439/

Bench 6445111
