### PR TITLE
Increase futility margin if the opponent has a guaranteed SEE > 0

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -291,6 +291,52 @@ Bitboard GetPieceBB(const S_Board* pos, const int piecetype) {
     return pos->GetPieceColorBB(piecetype, WHITE) | pos->GetPieceColorBB(piecetype, BLACK);
 }
 
+bool oppCanWinMaterial(const S_Board* pos, const int side) {
+    Bitboard occ = pos->Occupancy(BOTH);
+    Bitboard  us = pos->Occupancy(side);
+    Bitboard oppPawns = pos->GetPieceColorBB(PAWN, side ^ 1);
+    Bitboard ourPawns = pos->GetPieceColorBB(PAWN, side);
+    while (oppPawns) {
+        int source_square = GetLsbIndex(oppPawns);
+        if (pawn_attacks[side ^ 1][source_square] & (us ^ ourPawns))
+            return true;
+
+        pop_lsb(ourPawns);
+    }
+
+    Bitboard oppKnights = pos->GetPieceColorBB(KNIGHT, side ^ 1);
+    Bitboard ourKnights = pos->GetPieceColorBB(KNIGHT, side);
+    Bitboard oppBishops = pos->GetPieceColorBB(BISHOP, side ^ 1);
+    Bitboard ourBishops = pos->GetPieceColorBB(BISHOP, side);
+    while (oppKnights) {
+        int source_square = GetLsbIndex(oppKnights);
+        if (knight_attacks[source_square] & (us ^ ourPawns ^ ourKnights ^ ourBishops))
+            return true;
+
+        pop_lsb(oppKnights);
+    }
+
+    while (oppBishops) {
+        int source_square = GetLsbIndex(oppBishops);
+        if (GetBishopAttacks(source_square, occ) & (us ^ ourPawns ^ ourKnights ^ ourBishops))
+            return true;
+
+        pop_lsb(oppBishops);
+    }
+
+    Bitboard oppRooks = pos->GetPieceColorBB(ROOK, side ^ 1);
+    Bitboard ourRooks = pos->GetPieceColorBB(ROOK, side);
+    while (oppRooks) {
+        int source_square = GetLsbIndex(oppRooks);
+        if (GetRookAttacks(source_square, occ) & (us ^ ourPawns ^ ourKnights ^ ourBishops ^ ourRooks))
+            return true;
+
+        pop_lsb(ourRooks);
+    }
+
+    return false;
+}
+
 Bitboard getThreats(const S_Board* pos, const int side) {
     // Take the occupancies of both positions, encoding where all the pieces on the board reside
     Bitboard occ = pos->Occupancy(BOTH);

--- a/src/board.h
+++ b/src/board.h
@@ -247,6 +247,8 @@ void ResetInfo(S_SearchINFO* info);
 [[nodiscard]] Bitboard GetPieceBB(const S_Board* pos, const int piecetype);
 // Returns the threats bitboard of the pieces of <side> color
 [[nodiscard]] Bitboard getThreats(const S_Board* pos, const int side);
+// Returns whether the opponent of <side> has a guaranteed SEE > 0
+[[nodiscard]] bool oppCanWinMaterial(const S_Board* pos, const int side);
 // Return a piece based on the type and the color
 [[nodiscard]] int GetPiece(const int piecetype, const int color);
 // Returns the piece_type of a piece

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -424,8 +424,8 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, S_ThreadData* td
     if (!pvNode) {
         // Reverse futility pruning
         if (   depth < 10
-            && eval - 81 * (depth - improving) >= beta
-            && abs(eval) < mate_found)
+            && abs(eval) < mate_found
+            && eval - (81 + 10 * oppCanWinMaterial(pos, pos->side)) * depth + 81 * improving >= beta)
             return eval;
 
         // Null move pruning: If our position is so good that we can give the opponent a free move and still fail high, 

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-6.0.1"
+#define NAME "Alexandria-6.0.2"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
Inspired by Koivisto, and I found out about it in Berserk

Elo   | 2.57 +- 2.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 34402 W: 8252 L: 7998 D: 18152
Penta | [141, 3919, 8831, 4165, 145]
https://antares2262.pythonanywhere.com/test/111/

Bench 7033692