### PR TITLE
Introduce Triple Extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -567,7 +567,7 @@ moves_loop:
                     if (   !pvNode
                         &&  singularScore < singularBeta - 17
                         &&  ss->doubleExtensions <= 11) {
-                        extension = 2;
+                        extension = 2 + (IsQuiet(ttMove) && singularScore < singularBeta - 300);
                         ss->doubleExtensions = (ss - 1)->doubleExtensions + 1;
                     }
                 }

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-6.0.3"
+#define NAME "Alexandria-6.0.4"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
Triple instead of double extend quiet ttMoves with singular score far below singular beta. This threshold value is initially set to 300, there is scope for more scaling by reducing it.

Passed LTC:
https://chess.swehosting.se/test/5460/
ELO   | 1.92 +- 1.56 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 86848 W: 20054 L: 19573 D: 47221

Bench 7197125