### PR TITLE
Use move history in SEE threshold for move ordering

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -35,11 +35,12 @@ void ScoreMoves(Movepicker* mp) {
         }
         else if (isCapture(move)) {
             // Score by most valuable victim and capthist
-            int captured_piece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
-            moveList->moves[i].score = PieceValue[captured_piece] * 32 + GetCapthistScore(pos, sd, move);
+            int capturedPiece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
+            moveList->moves[i].score = PieceValue[capturedPiece] * 32 + GetCapthistScore(pos, sd, move);
             // Good captures get played before any move that isn't a promotion or a TT move
             // Bad captures are always played last, no matter how bad the history score of a quiet is, it will never be played after a bad capture
-            moveList->moves[i].score += SEE(pos, move, mp->SEEThreshold) ? goodCaptureScore : badCaptureScore;
+            int SEEThreshold = mp->SEEThreshold != score_none ? mp->SEEThreshold : -moveList->moves[i].score / 64;
+            moveList->moves[i].score += SEE(pos, move, SEEThreshold) ? goodCaptureScore : badCaptureScore;
             continue;
         }
         // First killer move always comes after the TT move,the promotions and the good captures and before anything else

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -24,5 +24,5 @@ struct Movepicker {
     int SEEThreshold;
 };
 
-void InitMP(Movepicker* mp, S_Board* pos, Search_data* sd, Search_stack* ss, const int ttMove, const bool capturesOnly, const int SEEThreshold = -108);
+void InitMP(Movepicker* mp, S_Board* pos, Search_data* sd, Search_stack* ss, const int ttMove, const bool capturesOnly, const int SEEThreshold = score_none);
 int NextMove(Movepicker* mp, const bool skipNonGood);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -803,7 +803,7 @@ int Quiescence(int alpha, int beta, S_ThreadData* td, Search_stack* ss) {
 
     Movepicker mp;
     // If we aren't in check we generate just the captures, otherwise we generate all the moves
-    InitMP(&mp, pos, sd, ss, ttMove, !inCheck);
+    InitMP(&mp, pos, sd, ss, ttMove, !inCheck, -108);
 
     int bestmove = NOMOVE;
     int move = NOMOVE;

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-6.0.6"
+#define NAME "Alexandria-6.0.7"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
Elo   | 2.55 +- 2.55 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 33278 W: 7934 L: 7690 D: 17654
Penta | [97, 3684, 8822, 3950, 86]
https://chess.swehosting.se/test/5514/

Bench 6948840