### PR TITLE
Increment depth when we double extend at low depths

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -569,6 +569,7 @@ moves_loop:
                         &&  ss->doubleExtensions <= 11) {
                         extension = 2 + (!isTactical(ttMove) && singularScore < singularBeta - 100);
                         ss->doubleExtensions = (ss - 1)->doubleExtensions + 1;
+                        depth += depth < 10;
                     }
                 }
                 else if (singularBeta >= beta)

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#define NAME "Alexandria-6.0.11"
+#define NAME "Alexandria-6.0.12"
 
 // define bitboard data type
 using Bitboard = uint64_t;


### PR DESCRIPTION
Elo   | 2.75 +- 2.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 31414 W: 7558 L: 7309 D: 16547
Penta | [136, 3592, 8015, 3815, 149]
https://chess.swehosting.se/test/5595/

Bench 6110305