### PR TITLE
Age TT entries and use it in our replacement scheme

### DIFF
--- a/src/ttable.h
+++ b/src/ttable.h
@@ -10,14 +10,18 @@ PACK(struct S_HashEntry {
     int16_t eval = SCORE_NONE;
     TTKey ttKey = 0;
     uint8_t depth = 0;
-    uint8_t boundPV = HFNONE;
+    uint8_t ageBoundPV = HFNONE;
+    // lower 2 bits is bound, 3rd bit is PV, next 5 is age
 });
 
 struct S_HashTable {
     std::vector<S_HashEntry> pTable;
+    uint8_t age;
 };
 
 extern S_HashTable HashTable[1];
+
+constexpr uint8_t MAX_AGE = 1 << 5;
 
 void ClearHashTable(S_HashTable* table);
 // Initialize an Hashtable of size MB
@@ -25,7 +29,7 @@ void InitHashTable(S_HashTable* table, uint64_t MB);
 
 [[nodiscard]] bool ProbeHashEntry(const ZobristKey posKey, S_HashEntry* tte);
 
-void StoreHashEntry(const ZobristKey key, const int16_t move, int score, int16_t eval, const int flag, const int depth, const bool pv, const bool wasPV);
+void StoreHashEntry(const ZobristKey key, const int16_t move, int score, int16_t eval, const int bound, const int depth, const bool pv, const bool wasPV);
 
 [[nodiscard]] uint64_t Index(const ZobristKey posKey);
 
@@ -41,8 +45,14 @@ int16_t MoveToTT(int move);
 
 int MoveFromTT(S_Board *pos, int16_t packed_move);
 
-uint8_t BoundFromTT(uint8_t boundPV);
+uint8_t BoundFromTT(uint8_t ageBoundPV);
 
-bool FormerPV(uint8_t boundPV);
+bool FormerPV(uint8_t ageBoundPV);
 
-uint8_t PackToTT(uint8_t flag, bool wasPV);
+uint8_t AgeFromTT(uint8_t ageBoundPV);
+
+uint8_t PackToTT(uint8_t bound, bool wasPV, uint8_t age);
+
+void UpdateEntryAge(uint8_t &ageBoundPV);
+
+void UpdateTableAge();

--- a/src/types.h
+++ b/src/types.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstdint>
 
-#define NAME "Alexandria-6.0.13"
+#define NAME "Alexandria-6.0.14"
 
 #define start_position "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -289,7 +289,6 @@ void UciLoop(int argc, char** argv) {
         // parse UCI "isready" command
         else if (input == "isready") {
             std::cout << "readyok\n";
-
             continue;
         }
 


### PR DESCRIPTION
Elo   | 2.50 +- 2.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 35524 W: 8468 L: 8212 D: 18844
Penta | [143, 3983, 9263, 4221, 152]
https://chess.swehosting.se/test/5680/

Bench 6601039