### PR TITLE
Clamp continuation history properly

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -103,7 +103,10 @@ int GetCapthistScore(const S_Board* pos, const Search_data* sd, const int move) 
 
 int GetHistoryScore(const S_Board* pos, const Search_data* sd, const int move, const Search_stack* ss) {
     if (!isTactical(move))
-        return GetHHScore(pos, sd, move) + 2 * GetCHScore(sd, ss, move);
+        return   2 * GetHHScore(pos, sd, move)
+               + 2 * GetSingleCHScore(sd, ss, move, 1)
+               + 2 * GetSingleCHScore(sd, ss, move, 2)
+               +     GetSingleCHScore(sd, ss, move, 4);
     else
         return GetCapthistScore(pos, sd, move);
 }

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -22,18 +22,17 @@ void updateHHScore(const S_Board* pos, Search_data* sd, int move, int bonus) {
 }
 
 void updateCHScore(Search_data* sd, const Search_stack* ss, const int move, const int bonus) {
-    // Scale bonus to fix it in a [-32768;32768] range
-    const int scaledBonus = bonus - GetCHScore(sd, ss, move) * std::abs(bonus) / 32768;
     // Update move score
-    updateSingleCHScore(sd, ss, move, scaledBonus, 1);
-    updateSingleCHScore(sd, ss, move, scaledBonus, 2);
-    updateSingleCHScore(sd, ss, move, scaledBonus, 4);
+    updateSingleCHScore(sd, ss, move, bonus, 1);
+    updateSingleCHScore(sd, ss, move, bonus, 2);
+    updateSingleCHScore(sd, ss, move, bonus, 4);
 }
 
 void updateSingleCHScore(Search_data* sd, const Search_stack* ss, const int move, const int bonus, const int offset) {
     if (ss->ply >= offset) {
         const int previousMove = (ss - offset)->move;
-        sd->contHist[Piece(previousMove)][To(previousMove)][Piece(move)][To(move)] += bonus;
+        const int scaledBonus = bonus - GetSingleCHScore(sd, ss, move, offset) * std::abs(bonus) / 65536;
+        sd->contHist[Piece(previousMove)][To(previousMove)][Piece(move)][To(move)] += scaledBonus;
     }
 }
 
@@ -103,10 +102,7 @@ int GetCapthistScore(const S_Board* pos, const Search_data* sd, const int move) 
 
 int GetHistoryScore(const S_Board* pos, const Search_data* sd, const int move, const Search_stack* ss) {
     if (!isTactical(move))
-        return   2 * GetHHScore(pos, sd, move)
-               + 2 * GetSingleCHScore(sd, ss, move, 1)
-               + 2 * GetSingleCHScore(sd, ss, move, 2)
-               +     GetSingleCHScore(sd, ss, move, 4);
+        return GetHHScore(pos, sd, move) + 2 * GetCHScore(sd, ss, move);
     else
         return GetCapthistScore(pos, sd, move);
 }

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -22,10 +22,12 @@ void updateHHScore(const S_Board* pos, Search_data* sd, int move, int bonus) {
 }
 
 void updateCHScore(Search_data* sd, const Search_stack* ss, const int move, const int bonus) {
+    // Average out the bonus across the 3 conthist entries
+    const int scaledBonus = bonus - GetCHScore(sd, ss, move) * std::abs(bonus) / 32768;
     // Update move score
-    updateSingleCHScore(sd, ss, move, bonus, 1);
-    updateSingleCHScore(sd, ss, move, bonus, 2);
-    updateSingleCHScore(sd, ss, move, bonus, 4);
+    updateSingleCHScore(sd, ss, move, scaledBonus, 1);
+    updateSingleCHScore(sd, ss, move, scaledBonus, 2);
+    updateSingleCHScore(sd, ss, move, scaledBonus, 4);
 }
 
 void updateSingleCHScore(Search_data* sd, const Search_stack* ss, const int move, const int bonus, const int offset) {

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -25,19 +25,15 @@ void updateCHScore(Search_data* sd, const Search_stack* ss, const int move, cons
     // Scale bonus to fix it in a [-32768;32768] range
     const int scaledBonus = bonus - GetCHScore(sd, ss, move) * std::abs(bonus) / 32768;
     // Update move score
-    if (ss->ply > 0) {
-        sd->contHist[Piece((ss - 1)->move)][To((ss - 1)->move)]
-            [Piece(move)][To(move)] += scaledBonus;
-        // Score followup
-        if (ss->ply > 1) {
-            sd->contHist[Piece((ss - 2)->move)][To((ss - 2)->move)]
-                [Piece(move)][To(move)] += scaledBonus;
+    updateSingleCHScore(sd, ss, move, scaledBonus, 1);
+    updateSingleCHScore(sd, ss, move, scaledBonus, 2);
+    updateSingleCHScore(sd, ss, move, scaledBonus, 4);
+}
 
-            if (ss->ply > 3) {
-                sd->contHist[Piece((ss - 4)->move)][To((ss - 4)->move)]
-                    [Piece(move)][To(move)] += scaledBonus;
-            }
-        }
+void updateSingleCHScore(Search_data* sd, const Search_stack* ss, const int move, const int bonus, const int offset) {
+    if (ss->ply >= offset) {
+        const int previousMove = (ss - offset)->move;
+        sd->contHist[Piece(previousMove)][To(previousMove)][Piece(move)][To(move)] += bonus;
     }
 }
 
@@ -52,30 +48,30 @@ void updateCapthistScore(const S_Board* pos, Search_data* sd, int move, int bonu
 }
 
 // Update all histories
-void UpdateHistories(const S_Board* pos, Search_data* sd, Search_stack* ss, const int depth, const int bestmove, const S_MOVELIST* quiet_moves, const S_MOVELIST* noisy_moves) {
+void UpdateHistories(const S_Board* pos, Search_data* sd, Search_stack* ss, const int depth, const int bestMove, const S_MOVELIST* quietMoves, const S_MOVELIST* noisyMoves) {
     const int bonus = history_bonus(depth);
-    if (!isTactical(bestmove))
+    if (!isTactical(bestMove))
     {
-        // increase bestmove HH and CH score
-        updateHHScore(pos, sd, bestmove, bonus);
-        updateCHScore(sd, ss, bestmove, bonus);
+        // increase bestMove HH and CH score
+        updateHHScore(pos, sd, bestMove, bonus);
+        updateCHScore(sd, ss, bestMove, bonus);
         // Loop through all the quiet moves
-        for (int i = 0; i < quiet_moves->count; i++) {
+        for (int i = 0; i < quietMoves->count; i++) {
             // For all the quiets moves that didn't cause a cut-off decrease the HH score
-            const int move = quiet_moves->moves[i].move;
-            if (move == bestmove) continue;
+            const int move = quietMoves->moves[i].move;
+            if (move == bestMove) continue;
             updateHHScore(pos, sd, move, -bonus);
             updateCHScore(sd, ss, move, -bonus);
         }
     }
     else {
-        // increase the bestmove Capthist score
-        updateCapthistScore(pos, sd, bestmove, bonus);
+        // increase the bestMove Capthist score
+        updateCapthistScore(pos, sd, bestMove, bonus);
     }
-    // For all the noisy moves that didn't cause a cut-off, even is the bestmove wasn't a noisy move, decrease the capthist score
-    for (int i = 0; i < noisy_moves->count; i++) {
-        const int move = noisy_moves->moves[i].move;
-        if (move == bestmove) continue;
+    // For all the noisy moves that didn't cause a cut-off, even is the bestMove wasn't a noisy move, decrease the capthist score
+    for (int i = 0; i < noisyMoves->count; i++) {
+        const int move = noisyMoves->moves[i].move;
+        if (move == bestMove) continue;
         updateCapthistScore(pos, sd, move, -bonus);
     }
 }
@@ -87,17 +83,14 @@ int GetHHScore(const S_Board* pos, const Search_data* sd, const int move) {
 
 // Returns the history score of a move
 int GetCHScore(const Search_data* sd, const Search_stack* ss, const int move) {
-    int score = 0;
-    const int previousMove = (ss - 1)->move;
-    const int previousPreviousMove = (ss - 2)->move;
-    const int previousPreviousPreviousPreviousMove = (ss - 4)->move;
-    if (previousMove)
-        score += sd->contHist[Piece(previousMove)][To(previousMove)][Piece(move)][To(move)];
-    if (previousPreviousMove)
-        score += sd->contHist[Piece(previousPreviousMove)][To(previousPreviousMove)][Piece(move)][To(move)];
-    if (previousPreviousPreviousPreviousMove)
-        score += sd->contHist[Piece(previousPreviousPreviousPreviousMove)][To(previousPreviousPreviousPreviousMove)][Piece(move)][To(move)];
-    return score;
+    return   GetSingleCHScore(sd, ss, move, 1)
+           + GetSingleCHScore(sd, ss, move, 2)
+           + GetSingleCHScore(sd, ss, move, 4);
+}
+
+int GetSingleCHScore(const Search_data* sd, const Search_stack* ss, const int move, const int offset) {
+    const int previousMove = (ss - offset)->move;
+    return previousMove ? sd->contHist[Piece(previousMove)][To(previousMove)][Piece(move)][To(move)] : 0;
 }
 
 // Returns the history score of a move

--- a/src/history.h
+++ b/src/history.h
@@ -6,15 +6,19 @@ struct Search_stack;
 struct S_MOVELIST;
 
 // Functions used to update the history heuristics
-void UpdateHistories(const S_Board* pos, Search_data* sd, Search_stack* ss, const int depth, const int bestmove, const S_MOVELIST* quiet_moves, const S_MOVELIST* noisy_moves);
-// Fuction that returns the histroy bonus
+void UpdateHistories(const S_Board* pos, Search_data* sd, Search_stack* ss, const int depth, const int bestMove, const S_MOVELIST* quietMoves, const S_MOVELIST* noisyMoves);
+// Fuction that returns the history bonus
 int history_bonus(const int depth);
 // Getters for the history heuristics
 [[nodiscard]] int GetHHScore(const S_Board* pos, const Search_data* sd, const int move);
 [[nodiscard]] int GetCHScore(const Search_data* sd, const Search_stack* ss, const int move);
+[[nodiscard]] int GetSingleCHScore(const Search_data* sd, const Search_stack* ss, const int move, const int offset);
 [[nodiscard]] int GetHistoryScore(const S_Board* pos, const Search_data* sd, const int move, const Search_stack* ss);
 [[nodiscard]] int GetCapthistScore(const S_Board* pos, const Search_data* sd, const int move);
 // Clean all the history tables
 void CleanHistories(Search_data* sd);
-// Updates the continuation history score for a single move
+// Updates history heuristics for a single move
+void updateHHScore(const S_Board* pos, Search_data* sd, int move, int bonus);
 void updateCHScore(Search_data* sd, const Search_stack* ss, const int move, const int bonus);
+void updateCapthistScore(const S_Board* pos, Search_data* sd, int move, int bonus);
+void updateSingleCHScore(Search_data* sd, const Search_stack* ss, const int move, const int bonus, const int offset);


### PR DESCRIPTION
Elo   | 2.06 +- 3.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 17734 W: 4209 L: 4104 D: 9421
Penta | [66, 2004, 4633, 2087, 77]
https://chess.swehosting.se/test/5701/

Bench 6324387