### PR TITLE
Fix clang compilation somewhat

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ _ROOT       := $(_THIS)
 EVALFILE     = $(NETWORK_NAME)
 CXX         := g++
 TARGET      := Alexandria
-WARNINGS     = -Wall -Wcast-qual -Wextra -Wshadow -Wdouble-promotion -Wformat=2 -Wnull-dereference -Wlogical-op -Wold-style-cast -Wundef -pedantic
+WARNINGS     = -Wall -Wcast-qual -Wextra -Wshadow -Wdouble-promotion -Wformat=2 -Wnull-dereference -Wold-style-cast -Wundef -pedantic
 CXXFLAGS    :=  -funroll-loops -O3 -flto -fno-exceptions -std=gnu++2a -DNDEBUG $(WARNINGS)
 NATIVE       = -march=native
 
@@ -14,6 +14,10 @@ NATIVE       = -march=native
 NAME        := Alexandria
 
 TMPDIR = .tmp
+
+ifeq ($(CXX), g++)
+WARNINGS += -Wlogical-op
+endif
 
 # Detect Clang
 ifeq ($(CXX), clang++)

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -4,8 +4,11 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
-#include <immintrin.h>
 #include "incbin/incbin.h"
+
+#if defined(USE_AVX512) || defined(USE_AVX2)
+#include <immintrin.h>
+#endif
 
 // Macro to embed the default efficiently updatable neural network (NNUE) file
 // data in the engine binary (using incbin.h, by Dale Weiler).

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -3,7 +3,10 @@
 #include <cstdint>
 #include <array>
 #include <vector>
+
+#if defined(USE_AVX512) || defined(USE_AVX2)
 #include <immintrin.h>
+#endif
 
 constexpr int INPUT_WEIGHTS = 768;
 constexpr int HIDDEN_SIZE = 1024;


### PR DESCRIPTION
clang/clang++ does not support the -Wlogical-op flag, so only enable it for g++.