### PR TITLE
Split SEE and material values and tweak each (#374)

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -19,7 +19,7 @@ void ScoreMoves(Movepicker* mp) {
             int capturedPiece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
             // If we captured an empty piece this means the move is a non capturing promotion, we can pretend we captured a pawn to use a slot of the table that would've otherwise went unused (you can't capture pawns on the 1st/8th rank)
             if (capturedPiece == EMPTY) capturedPiece = PAWN;
-            moveList->moves[i].score = PieceValue[capturedPiece] * 32 + GetCapthistScore(pos, sd, move);
+            moveList->moves[i].score = SEEValue[capturedPiece] * 32 + GetCapthistScore(pos, sd, move);
             // Good captures get played before any move that isn't a promotion or a TT move
             // Bad captures are always played last, no matter how bad the history score of a quiet is, it will never be played after a bad capture
             int SEEThreshold = mp->SEEThreshold != SCORE_NONE ? mp->SEEThreshold : -moveList->moves[i].score / 64;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -443,16 +443,6 @@ int GetEpSquare(const Position* pos) {
     return pos->enPas;
 }
 
-uint64_t GetMaterialValue(const Position* pos) {
-    int pawns = CountBits(GetPieceBB(pos, PAWN));
-    int knights = CountBits(GetPieceBB(pos, KNIGHT));
-    int bishops = CountBits(GetPieceBB(pos, BISHOP));
-    int rooks = CountBits(GetPieceBB(pos, ROOK));
-    int queens = CountBits(GetPieceBB(pos, QUEEN));
-
-    return pawns * PieceValue[PAWN] + knights * PieceValue[KNIGHT] + bishops * PieceValue[BISHOP] + rooks * PieceValue[ROOK] + queens * PieceValue[QUEEN];
-}
-
 void Accumulate(NNUE::accumulator& board_accumulator, Position* pos) {
     for (int i = 0; i < HIDDEN_SIZE; i++) {
         board_accumulator[0][i] = net.featureBias[i];

--- a/src/position.h
+++ b/src/position.h
@@ -214,7 +214,6 @@ void ResetInfo(SearchInfo* info);
 void UpdatePinsAndCheckers(Position* pos, const int side);
 Bitboard RayBetween(int square1, int square2);
 [[nodiscard]] int GetEpSquare(const Position* pos);
-[[nodiscard]] uint64_t GetMaterialValue(const Position* pos);
 void Accumulate(NNUE::accumulator& board_accumulator, Position* pos);
 ZobristKey keyAfter(const Position* pos, const int move);
 void saveBoardState(Position* pos);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -120,14 +120,14 @@ bool SEE(const Position* pos, const int move, const int threshold) {
 
     int target = pos->PieceOn(to);
     // Making the move and not losing it must beat the threshold
-    int value = PieceValue[target] - threshold;
+    int value = SEEValue[target] - threshold;
 
     if (value < 0)
         return false;
 
     int attacker = pos->PieceOn(from);
     // Trivial if we still beat the threshold after losing the piece
-    value -= PieceValue[attacker];
+    value -= SEEValue[attacker];
 
     if (value >= 0)
         return true;
@@ -159,7 +159,7 @@ bool SEE(const Position* pos, const int move, const int threshold) {
 
         side ^= 1;
 
-        value = -value - 1 - PieceValue[pt];
+        value = -value - 1 - SEEValue[pt];
 
         // Value beats threshold, or can't beat threshold (negamaxed)
         if (value >= 0) {

--- a/src/types.h
+++ b/src/types.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstdint>
 
-#define NAME "Alexandria-6.0.17"
+#define NAME "Alexandria-6.0.18"
 
 #define start_position "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 
@@ -105,8 +105,8 @@ constexpr int PieceType[12] = { PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING,
                                 PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING };
 
 // Contains the material Values of the pieces
-constexpr int PieceValue[15] = { 100, 300, 300, 450, 900, 0,
-                                 100, 300, 300, 450, 900, 0, 0, 0, 0 };
+constexpr int SEEValue[15] = { 100, 422, 422, 642, 1015, 0,
+                               100, 422, 422, 642, 1015, 0, 0, 0, 0 };
 
 enum {
     queenPromotionScore = 2000000001,


### PR DESCRIPTION
Elo | 2.99 +- 2.78 (95%)
SPRT | 8.0+0.08s Threads=1 Hash=16MB
LLR | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 28500 W: 6897 L: 6652 D: 14951
Penta | [112, 3374, 7057, 3571, 136]
https://chess.swehosting.se/test/5879/

Bench 5839928