### PR TITLE
Put continuation history entries on the stack

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -11,14 +11,14 @@ void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const
 int history_bonus(const int depth);
 // Getters for the history heuristics
 [[nodiscard]] int GetHHScore(const Position* pos, const SearchData* sd, const int move);
-[[nodiscard]] int GetCHScore(const SearchData* sd, const SearchStack* ss, const int move);
-[[nodiscard]] int GetSingleCHScore(const SearchData* sd, const SearchStack* ss, const int move, const int offset);
-[[nodiscard]] int GetHistoryScore(const Position* pos, const SearchData* sd, const int move, const SearchStack* ss);
+[[nodiscard]] int GetCHScore(const SearchStack* ss, const int move);
+[[nodiscard]] int GetSingleCHScore(const SearchStack* ss, const int move, const int offset);
 [[nodiscard]] int GetCapthistScore(const Position* pos, const SearchData* sd, const int move);
+[[nodiscard]] int GetHistoryScore(const Position* pos, const SearchData* sd, const int move, const SearchStack* ss);
 // Clean all the history tables
 void CleanHistories(SearchData* sd);
 // Updates history heuristics for a single move
 void updateHHScore(const Position* pos, SearchData* sd, int move, int bonus);
-void updateCHScore(SearchData* sd, const SearchStack* ss, const int move, const int bonus);
+void updateCHScore(SearchStack* ss, const int move, const int bonus);
 void updateCapthistScore(const Position* pos, SearchData* sd, int move, int bonus);
-void updateSingleCHScore(SearchData* sd, const SearchStack* ss, const int move, const int bonus, const int offset);
+void updateSingleCHScore(SearchStack* ss, const int move, const int bonus, const int offset);

--- a/src/search.h
+++ b/src/search.h
@@ -8,10 +8,11 @@ struct SearchStack {
     // don't init, it will be init by search before entering the negamax method
     int excludedMove;
     int16_t staticEval;
-    int move = {};
+    int move;
     int ply;
     int searchKillers[2];
     int doubleExtensions;
+    int (*contHistEntry)[12 * 64];
 };
 
 struct SearchData {


### PR DESCRIPTION
Elo   | 2.85 +- 4.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 13788 W: 3374 L: 3261 D: 7153
Penta | [48, 1587, 3517, 1688, 54]
https://chess.swehosting.se/test/6106/

Bench 6027240