### PR TITLE
Make SEE more accurate

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -407,7 +407,7 @@ bool BoardHasNonPawns(const Position* pos, const int side) {
 
 // Get on what square of the board the king of color c resides
 int KingSQ(const Position* pos, const int c) {
-    return (GetLsbIndex(pos->GetPieceColorBB( KING, c)));
+    return GetLsbIndex(pos->GetPieceColorBB(KING, c));
 }
 
 void UpdatePinsAndCheckers(Position* pos, const int side) {

--- a/src/position.h
+++ b/src/position.h
@@ -186,22 +186,35 @@ void ResetInfo(SearchInfo* info);
 
 // Retrieve a generic piece (useful when we don't know what type of piece we are dealing with
 [[nodiscard]] Bitboard GetPieceBB(const Position* pos, const int piecetype);
+
 // Returns the threats bitboard of the pieces of <side> color
 [[nodiscard]] Bitboard getThreats(const Position* pos, const int side);
+
 // Returns whether the opponent of <side> has a guaranteed SEE > 0
 [[nodiscard]] bool oppCanWinMaterial(const Position* pos, const int side);
+
 // Return a piece based on the type and the color
 [[nodiscard]] int GetPiece(const int piecetype, const int color);
+
 // Returns the piece_type of a piece
 [[nodiscard]] int GetPieceType(const int piece);
+
 // Returns true if side has at least one piece on the board that isn't a pawn, false otherwise
 [[nodiscard]] bool BoardHasNonPawns(const Position* pos, const int side);
+
 // Get on what square of the board the king of color c resides
 [[nodiscard]] int KingSQ(const Position* pos, const int c);
+
 void UpdatePinsAndCheckers(Position* pos, const int side);
+
 Bitboard RayBetween(int square1, int square2);
+
 [[nodiscard]] int GetEpSquare(const Position* pos);
+
 void Accumulate(NNUE::accumulator& board_accumulator, Position* pos);
+
 ZobristKey keyAfter(const Position* pos, const int move);
+
 void saveBoardState(Position* pos);
+
 void restorePreviousBoardState(Position* pos);

--- a/src/types.h
+++ b/src/types.h
@@ -3,7 +3,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-6.1.5"
+#define NAME "Alexandria-6.1.6"
 
 #define start_position "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 


### PR DESCRIPTION
It now handles promotions, en passant and castling correctly. Correct promotion handling also allows us to enable it for qsearch pruning.

Elo   | 2.46 +- 2.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 36390 W: 8839 L: 8581 D: 18970
Penta | [136, 4182, 9307, 4428, 142]
https://chess.swehosting.se/test/6125/

Bench 5639746