### PR TITLE
Move unpack fix

### DIFF
--- a/Contributors
+++ b/Contributors
@@ -1,4 +1,5 @@
 # Everyone that significantly contributed to Alex code (in alphabetical order)
+Beanie496 - fixed a small bug
 Ciekce - the entirety of the tuning setup
 Cosmo - relative NNUE inference code
 Disservin - Makefile and CI PR

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -1,17 +1,17 @@
 #include "random.h"
 
 // pseudo random number state
-unsigned int random_state = 1804289383;
+uint64_t random_state = 6379633040001738036;
 
 // generate 32-bit pseudo legal numbers
-unsigned int GetRandomU32Number() {
+uint64_t GetRandomU64Number() {
     // get current state
-    unsigned int number = random_state;
+    uint64_t number = random_state;
 
     // XOR shift algorithm
     number ^= number << 13;
-    number ^= number >> 17;
-    number ^= number << 5;
+    number ^= number >> 7;
+    number ^= number << 17;
 
     // update random number state
     random_state = number;
@@ -22,15 +22,5 @@ unsigned int GetRandomU32Number() {
 
 // generate 64-bit pseudo legal numbers
 Bitboard GetRandomBitboardNumber() {
-    // define 4 random numbers
-    Bitboard n1, n2, n3, n4;
-
-    // init random numbers slicing 16 bits from MS1B side
-    n1 = static_cast<Bitboard>((GetRandomU32Number())) & 0xFFFF;
-    n2 = static_cast<Bitboard>((GetRandomU32Number())) & 0xFFFF;
-    n3 = static_cast<Bitboard>((GetRandomU32Number())) & 0xFFFF;
-    n4 = static_cast<Bitboard>((GetRandomU32Number())) & 0xFFFF;
-
-    // return random number
-    return n1 | (n2 << 16) | (n3 << 32) | (n4 << 48);
+    return static_cast<Bitboard>(GetRandomU64Number());
 }

--- a/src/random.h
+++ b/src/random.h
@@ -3,10 +3,10 @@
 #include "types.h"
 
 // pseudo random number state
-extern unsigned int random_state;
+extern uint64_t random_state;
 
 // generate 32-bit pseudo legal numbers
-[[nodiscard]] unsigned int GetRandomU32Number();
+[[nodiscard]] uint64_t GetRandomU32Number();
 
 // generate 64-bit pseudo legal numbers
 [[nodiscard]] Bitboard GetRandomBitboardNumber();

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -134,7 +134,7 @@ int MoveFromTT(Position *pos, int16_t packed_move) {
         return NOMOVE;
 
     const int piece = pos->PieceOn(From(packed_move));
-    return (packed_move | (piece << 16));
+    return (static_cast<int>(static_cast<uint16_t>(packed_move)) | (piece << 16));
 }
 
 uint8_t BoundFromTT(uint8_t ageBoundPV) {


### PR DESCRIPTION
Fix moves being unpacked incorrectly from the TT if the first bit is a 1.

Passed non-regression STC:
Elo   | 0.83 +- 2.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 34140 W: 8030 L: 7948 D: 18162
Penta | [129, 4067, 8599, 4143, 132]
https://chess.swehosting.se/test/6350

This also simplifies the random number generator, on request :)