### PR TITLE
Use a specialized makemove function for each movetype

### DIFF
--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -61,7 +61,6 @@ void inline HashKey(Position* pos, ZobristKey key) {
 }
 
 void MakeCastle(const int move, Position* pos) {
-    pos->historyStackHead++;
     // parse move
     const int sourceSquare = From(move);
     const int targetSquare = To(move);
@@ -120,8 +119,6 @@ void MakeEp(const int move, Position* pos) {
     const int capturedPieceLocation = targetSquare + SOUTH;
     ClearPieceNNUE(pieceCap, capturedPieceLocation, pos);
 
-    pos->historyStackHead++;
-
     // Remove the piece fom the square it moved from
     ClearPieceNNUE(piece, sourceSquare, pos);
     // Set the piece to the destination square, if it was a promotion we directly set the promoted piece
@@ -142,8 +139,6 @@ void MakePromo(const int move, Position* pos) {
     const int piece = Piece(move);
     const int promotedPiece = GetPiece(getPromotedPiecetype(move), pos->side);
 
-    pos->historyStackHead++;
-    
     // Remove the piece fom the square it moved from
     ClearPieceNNUE(piece, sourceSquare, pos);
     // Set the piece to the destination square, if it was a promotion we directly set the promoted piece
@@ -176,8 +171,6 @@ void MakePromocapture(const int move, Position* pos) {
 
     pos->history[pos->historyStackHead].capture = pieceCap;
 
-    pos->historyStackHead++;
-
     // Remove the piece fom the square it moved from
     ClearPieceNNUE(piece, sourceSquare, pos);
     // Set the piece to the destination square, if it was a promotion we directly set the promoted piece
@@ -203,7 +196,6 @@ void MakeQuiet(const int move, Position* pos) {
     if (GetPieceType(piece) == PAWN)
         pos->fiftyMove = 0;
 
-    pos->historyStackHead++;
     MovePieceNNUE(piece,sourceSquare,targetSquare,pos);
 
     // Reset EP square
@@ -230,8 +222,6 @@ void MakeCapture(const int move, Position* pos) {
     ClearPieceNNUE(pieceCap, targetSquare, pos);
     pos->history[pos->historyStackHead].capture = pieceCap;
 
-    pos->historyStackHead++;
-
     MovePieceNNUE(piece,sourceSquare,targetSquare,pos);
 
     // Reset EP square
@@ -245,9 +235,8 @@ void MakeCapture(const int move, Position* pos) {
 }
 
 void MakeDP(const int move, Position* pos)
-{
-    pos->fiftyMove = 0;
-    pos->historyStackHead++;
+{   pos->fiftyMove = 0;
+
     // parse move
     const int sourceSquare = From(move);
     const int targetSquare = To(move);
@@ -414,6 +403,7 @@ void MakeMove(const int move, Position* pos) {
     else {
         MakeCapture(move, pos);
     }
+    pos->historyStackHead++;
     // change side
     pos->ChangeSide();
     // Xor the new side into the key

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -514,8 +514,10 @@ void MakeNullMove(Position* pos) {
     // Store position key in the array of searched position
     pos->played_positions.emplace_back(pos->posKey);
     // Update the zobrist key asap so we can prefetch
-    if (GetEpSquare(pos) != no_sq)
+    if (GetEpSquare(pos) != no_sq) {
         HashKey(pos, enpassant_keys[GetEpSquare(pos)]);
+        pos->enPas = no_sq;
+    }
     pos->ChangeSide();
     HashKey(pos, SideKey);
     TTPrefetch(pos->GetPoskey());
@@ -524,9 +526,6 @@ void MakeNullMove(Position* pos) {
     pos->historyStackHead++;
     pos->fiftyMove++;
     pos->plyFromNull = 0;
-
-    // reset enpassant square
-    pos->enPas = no_sq;
 
     // Update pinmasks and checkers
     UpdatePinsAndCheckers(pos, pos->side);

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -216,6 +216,34 @@ void MakeQuiet(const int move, Position* pos) {
     UpdateCastlingPerms(pos, sourceSquare, targetSquare);
 }
 
+void MakeCapture(const int move, Position* pos) {
+    // parse move
+    const int sourceSquare = From(move);
+    const int targetSquare = To(move);
+    const int piece = Piece(move);
+
+    pos->fiftyMove = 0;
+
+    const int pieceCap = pos->pieces[targetSquare];
+    assert(pieceCap != EMPTY);
+    assert(GetPieceType(pieceCap) != KING);
+    ClearPieceNNUE(pieceCap, targetSquare, pos);
+    pos->history[pos->historyStackHead].capture = pieceCap;
+
+    pos->historyStackHead++;
+
+    MovePieceNNUE(piece,sourceSquare,targetSquare,pos);
+
+    // Reset EP square
+    if (GetEpSquare(pos) != no_sq){
+        HashKey(pos, enpassant_keys[GetEpSquare(pos)]);
+        // reset enpassant square
+        pos->enPas = no_sq;
+    }
+
+    UpdateCastlingPerms(pos, sourceSquare, targetSquare);
+}
+
 void MakeDP(const int move, Position* pos)
 {
     pos->fiftyMove = 0;
@@ -384,32 +412,7 @@ void MakeMove(const int move, Position* pos) {
         MakeQuiet(move,pos);
     }
     else {
-        // parse move
-        const int sourceSquare = From(move);
-        const int targetSquare = To(move);
-        const int piece = Piece(move);
-
-        pos->fiftyMove = 0;
-
-        const int pieceCap = pos->pieces[targetSquare];
-        const int capturedPieceLocation = targetSquare;
-        assert(pieceCap != EMPTY);
-        assert(GetPieceType(pieceCap) != KING);
-        ClearPieceNNUE(pieceCap, capturedPieceLocation, pos);
-        pos->history[pos->historyStackHead].capture = pieceCap;
-
-        pos->historyStackHead++;
-
-        MovePieceNNUE(piece,sourceSquare,targetSquare,pos);
-
-        // Reset EP square
-        if (GetEpSquare(pos) != no_sq){
-            HashKey(pos, enpassant_keys[GetEpSquare(pos)]);
-            // reset enpassant square
-            pos->enPas = no_sq;
-        }
-
-        UpdateCastlingPerms(pos, sourceSquare, targetSquare);
+        MakeCapture(move, pos);
     }
     // change side
     pos->ChangeSide();

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -4,6 +4,12 @@
 #include "position.h"
 #include "init.h"
 
+void MakeCastle(const int move, Position *Position);
+
+void MakeDP(const int move, Position *pPosition);
+
+void MakeEp(const int move, Position *pos);
+
 // Remove a piece from a square
 void ClearPiece(const int piece, const int from, Position* pos) {
     const int color = Color[piece];
@@ -173,11 +179,6 @@ void MakeMove(const int move, Position* pos) {
     pos->accumStack[pos->accumStackHead] = pos->AccumulatorTop();
     pos->accumStackHead++;
 
-    // parse move
-    const int sourceSquare = From(move);
-    const int targetSquare = To(move);
-    const int piece = Piece(move);
-    const int promotedPiece = GetPiece(getPromotedPiecetype(move), pos->side);
     // parse move flag
     const bool capture = isCapture(move);
     const bool doublePush = isDP(move);
@@ -187,50 +188,142 @@ void MakeMove(const int move, Position* pos) {
     // increment fifty move rule counter
     pos->fiftyMove++;
     pos->plyFromNull++;
+    pos->hisPly++;
+
+    if(castling){
+        MakeCastle(move,pos);
+    }
+    else if(doublePush){
+        MakeDP(move,pos);
+    }
+    else if(enpass){
+        MakeEp(move,pos);
+    }
+    else {
+        // parse move
+        const int sourceSquare = From(move);
+        const int targetSquare = To(move);
+        const int piece = Piece(move);
+        const int promotedPiece = GetPiece(getPromotedPiecetype(move), pos->side);
+
+        // if a pawn was moved or a capture was played reset the 50 move rule counter
+        if (GetPieceType(piece) == PAWN || capture)
+            pos->fiftyMove = 0;
+
+        // handling capture moves
+        if (capture) {
+            const int pieceCap = pos->pieces[targetSquare];
+            const int capturedPieceLocation = targetSquare;
+            assert(pieceCap != EMPTY);
+            assert(GetPieceType(pieceCap) != KING);
+            ClearPieceNNUE(pieceCap, capturedPieceLocation, pos);
+
+            pos->history[pos->historyStackHead].capture = pieceCap;
+        }
+
+        pos->historyStackHead++;
+        // Remove the piece fom the square it moved from
+        ClearPieceNNUE(piece, sourceSquare, pos);
+        // Set the piece to the destination square, if it was a promotion we directly set the promoted piece
+        AddPieceNNUE(promotion ? promotedPiece : piece, targetSquare, pos);
+
+        // Reset EP square
+        if (GetEpSquare(pos) != no_sq){
+            HashKey(pos, enpassant_keys[GetEpSquare(pos)]);
+            // reset enpassant square
+            pos->enPas = no_sq;
+        }
+
+        UpdateCastlingPerms(pos, sourceSquare, targetSquare);
+    }
+    // change side
+    pos->ChangeSide();
+    // Xor the new side into the key
+    HashKey(pos, SideKey);
+    // Update pinmasks and checkers
+    UpdatePinsAndCheckers(pos, pos->side);
+    // If we are in check get the squares between the checking piece and the king
+    if (pos->checkers) {
+        const int kingSquare = KingSQ(pos, pos->side);
+        const int pieceLocation = GetLsbIndex(pos->checkers);
+        pos->checkMask = (1ULL << pieceLocation) | RayBetween(pieceLocation, kingSquare);
+    }
+    else
+        pos->checkMask = fullCheckmask;
+}
+
+void MakeEp(const int move, Position* pos) {
+    pos->fiftyMove = 0;
+
+    // parse move
+    const int sourceSquare = From(move);
+    const int targetSquare = To(move);
+    const int piece = Piece(move);
     const int SOUTH = pos->side == WHITE ? 8 : -8;
 
-    // if a pawn was moved or a capture was played reset the 50 move rule counter
-    if (GetPieceType(piece) == PAWN || capture)
-        pos->fiftyMove = 0;
+    const int pieceCap = GetPiece(PAWN, pos->side ^ 1);
+    pos->history[pos->historyStackHead].capture = pieceCap;
+    const int capturedPieceLocation = targetSquare + SOUTH;
+    ClearPieceNNUE(pieceCap, capturedPieceLocation, pos);
 
-    // handling capture moves
-    if (capture) {
-        const int pieceCap = enpass ? GetPiece(PAWN, pos->side ^ 1) : pos->pieces[targetSquare];
-        const int capturedPieceLocation = enpass ? targetSquare + SOUTH : targetSquare;
-        assert(pieceCap != EMPTY);
-        assert(GetPieceType(pieceCap) != KING);
-        ClearPieceNNUE(pieceCap, capturedPieceLocation, pos);
-
-        pos->history[pos->historyStackHead].capture = pieceCap;
-    }
-
-    // increment ply counters
-    pos->hisPly++;
     pos->historyStackHead++;
+
     // Remove the piece fom the square it moved from
     ClearPieceNNUE(piece, sourceSquare, pos);
     // Set the piece to the destination square, if it was a promotion we directly set the promoted piece
-    AddPieceNNUE(promotion ? promotedPiece : piece, targetSquare, pos);
+    AddPieceNNUE(piece, targetSquare, pos);
 
     // Reset EP square
-    if (GetEpSquare(pos) != no_sq)
-        HashKey(pos, enpassant_keys[GetEpSquare(pos)]);
-
-    // reset enpassant square
+    assert(GetEpSquare(pos) != no_sq);
+    HashKey(pos, enpassant_keys[GetEpSquare(pos)]);
     pos->enPas = no_sq;
+}
 
-    // handle double pawn push
-    if (doublePush) {
-        pos->enPas = targetSquare + SOUTH;
-        // hash enpassant
+void MakeDP(const int move, Position* pos)
+{
+    pos->fiftyMove = 0;
+    pos->historyStackHead++;
+    // parse move
+    const int sourceSquare = From(move);
+    const int targetSquare = To(move);
+    const int piece = Piece(move);
+
+    // Remove the piece fom the square it moved from
+    ClearPieceNNUE(piece, sourceSquare, pos);
+    // Set the piece to the destination square, if it was a promotion we directly set the promoted piece
+    AddPieceNNUE(piece, targetSquare, pos);
+    // Reset EP square
+    if (GetEpSquare(pos) != no_sq) {
         HashKey(pos, enpassant_keys[GetEpSquare(pos)]);
+        // reset enpassant square
+        pos->enPas = no_sq;
+    }
+    // Add new ep square
+    const int SOUTH = pos->side == WHITE ? 8 : -8;
+    pos->enPas = targetSquare + SOUTH;
+    HashKey(pos, enpassant_keys[GetEpSquare(pos)]);
+}
+
+void MakeCastle(const int move, Position* pos) {
+    pos->historyStackHead++;
+    // parse move
+    const int sourceSquare = From(move);
+    const int targetSquare = To(move);
+    const int piece = Piece(move);
+    // Remove the piece fom the square it moved from
+    ClearPieceNNUE(piece, sourceSquare, pos);
+    // Set the piece to the destination square, if it was a promotion we directly set the promoted piece
+    AddPieceNNUE(piece, targetSquare, pos);
+
+    // Reset EP square
+    if (GetEpSquare(pos) != no_sq){
+        HashKey(pos, enpassant_keys[GetEpSquare(pos)]);
+        pos->enPas = no_sq;
     }
 
-    // handle castling moves
-    if (castling) {
-        // switch target square
-        switch (targetSquare) {
-            // white castles king side
+    // move the rook
+    switch (targetSquare) {
+        // white castles king side
         case (g1):
             // move H rook
             MovePieceNNUE(WR, h1, f1, pos);
@@ -253,24 +346,8 @@ void MakeMove(const int move, Position* pos) {
             // move A rook
             MovePieceNNUE(BR, a8, d8, pos);
             break;
-        }
     }
     UpdateCastlingPerms(pos, sourceSquare, targetSquare);
-
-    // change side
-    pos->ChangeSide();
-    // Xor the new side into the key
-    HashKey(pos, SideKey);
-    // Update pinmasks and checkers
-    UpdatePinsAndCheckers(pos, pos->side);
-    // If we are in check get the squares between the checking piece and the king
-    if (pos->checkers) {
-        const int kingSquare = KingSQ(pos, pos->side);
-        const int pieceLocation = GetLsbIndex(pos->checkers);
-        pos->checkMask = (1ULL << pieceLocation) | RayBetween(pieceLocation, kingSquare);
-    }
-    else
-        pos->checkMask = fullCheckmask;
 }
 
 void UnmakeMove(const int move, Position* pos) {

--- a/src/types.h
+++ b/src/types.h
@@ -3,7 +3,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-6.1.9"
+#define NAME "Alexandria-6.1.10"
 
 #define start_position "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 


### PR DESCRIPTION
This  is one of the worst pieces of code i have ever written, it greatly increases code duplication for the sake of removing some branching, sadly this gains Elo 
Elo   | 1.69 +- 1.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 63340 W: 15081 L: 14772 D: 33487
Penta | [200, 7047, 16859, 7372, 192]