### PR TITLE
Introduce more qsearch pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -847,8 +847,10 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
 
             // Reverse Futility SEE pruning.
             // If our SEE score is so good that we can beat beta + a large margin, we can return a fail high early.
-            if (SEE(pos, move, beta - ss->staticEval + 439))
-                return beta;
+            if (SEE(pos, move, beta - ss->staticEval + 439)) {
+                bestScore = beta;
+                break;
+            }
         }
         // Speculative prefetch of the TT entry
         TTPrefetch(keyAfter(pos, move));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -834,15 +834,21 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
 
         totalMoves++;
 
-        // Futility pruning. If static eval is far below alpha, only search moves that win material.
         if (    bestScore > -MATE_FOUND
             && !inCheck
             &&  BoardHasNonPawns(pos, pos->side)) {
+
+            // Futility pruning. If static eval is far below alpha, only search moves that win material.
             const int futilityBase = ss->staticEval + 192;
             if (futilityBase <= alpha && !SEE(pos, move, 1)) {
                 bestScore = std::max(futilityBase, bestScore);
                 continue;
             }
+
+            // Reverse Futility SEE pruning.
+            // If our SEE score is so good that we can beat beta + a large margin, we can return a fail high early.
+            if (SEE(pos, move, beta - ss->staticEval + 439))
+                return beta;
         }
         // Speculative prefetch of the TT entry
         TTPrefetch(keyAfter(pos, move));


### PR DESCRIPTION
This is similar to and inspired by https://github.com/Luecx/Koivisto/commit/3c70d00283e8c23947ca5b8f73edf01292824517, but with a few differences:
1. It uses our SEE method which is comparative, speeding up the process
2. It saves the position into the TT before failing high

Elo   | 1.40 +- 1.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 99570 W: 23465 L: 23063 D: 53042
Penta | [331, 11861, 25031, 12199, 363]
https://chess.swehosting.se/test/6427/

Bench 6873782