### PR TITLE
Limit lmr reductions to totalmove 63

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -152,7 +152,7 @@ void InitReductions() {
     reductions[1][0][0] = 0;
 
     for (int i = 1; i < MAXDEPTH; i++) {
-        for (int j = 1; j < MAXDEPTH; j++) {
+        for (int j = 1; j < 64; j++) {
             reductions[0][i][j] = -0.25 + log(i) * log(j) / 2.25;
             reductions[1][i][j] = +1.00 + log(i) * log(j) / 2.00;
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -45,7 +45,7 @@ Bitboard rook_attacks[64][4096];
 
 Bitboard SQUARES_BETWEEN_BB[64][64];
 
-int reductions[2][MAXDEPTH][MAXPLY];
+int reductions[2][MAXDEPTH][64];
 int lmp_margin[MAXDEPTH][2];
 int see_margin[MAXDEPTH][2];
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -551,7 +551,7 @@ moves_loop:
             &&  bestScore > -MATE_FOUND) {
 
             // lmrDepth is the current depth minus the reduction the move would undergo in lmr, this is helpful because it helps us discriminate the bad moves with more accuracy
-            const int lmrDepth = std::max(0, depth - reductions[isQuiet][depth][totalMoves] + moveHistory / 16384);
+            const int lmrDepth = std::max(0, depth - reductions[isQuiet][depth][std::min(totalMoves, 63)] + moveHistory / 16384);
 
             if (!skipQuiets) {
 
@@ -637,7 +637,7 @@ moves_loop:
         if (totalMoves > 1 + pvNode && depth >= 3 && (isQuiet || !ttPv)) {
 
             // Get base reduction value
-            int depthReduction = reductions[isQuiet][depth][totalMoves];
+            int depthReduction = reductions[isQuiet][depth][std::min(totalMoves, 63)];
 
             // Fuck
             if (cutNode)


### PR DESCRIPTION
The lmr reduction init loop was using a misleading name, `maxdepth`, even when the field wasn't indexed with depth but total moves, at the same time if totalmoves ever reached a value > 127 (extremely unlikely given lmp and more but potentially possible, especially in an engine with less pruning) the table would index OOB, this removes the misleading name and caps the reduction index.

passed stc non reg
Elo   | 5.12 +- 6.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 5428 W: 1259 L: 1179 D: 2990
Penta | [11, 546, 1522, 622, 13]
https://chess.swehosting.se/test/6562/