### PR TITLE
Save static eval for non TT hits in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -824,8 +824,11 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
             bestScore = ttScore;
     }
     // If we don't have any useful info in the TT just call Evalpos
-    else
+    else {
         bestScore = ss->staticEval = EvalPosition(pos);
+        // Save the eval into the TT
+        StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, ss->staticEval, HFNONE, 0, pvNode, ttPv);
+    }
 
     // Stand pat
     if (bestScore >= beta)

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -42,7 +42,7 @@ void StoreTTEntry(const ZobristKey key, const int16_t move, int score, int eval,
     for (int i = 0; i < ENTRIES_PER_BUCKET; i++) {
         TTEntry* entry = &bucket->entries[i];
 
-        if (!entry->ttKey || entry->ttKey == key16) {
+        if (entry->ttKey == key16) {
             tte = entry;
             break;
         }

--- a/src/types.h
+++ b/src/types.h
@@ -3,7 +3,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-6.1.13"
+#define NAME "Alexandria-6.1.14"
 
 #define start_position "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 


### PR DESCRIPTION
Elo   | 1.90 +- 1.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 54578 W: 12713 L: 12414 D: 29451
Penta | [167, 6383, 13913, 6636, 190]
https://chess.swehosting.se/test/6759/

Bench 7027744