### PR TITLE
Increase max ply to 256

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -45,9 +45,9 @@ Bitboard rook_attacks[64][4096];
 
 Bitboard SQUARES_BETWEEN_BB[64][64];
 
-int reductions[2][MAXDEPTH][64];
-int lmp_margin[MAXDEPTH][2];
-int see_margin[MAXDEPTH][2];
+int reductions[2][64][64];
+int lmp_margin[64][2];
+int see_margin[64][2];
 
 // Initialize the Zobrist keys
 void initHashKeys() {
@@ -151,19 +151,19 @@ void InitReductions() {
     reductions[0][0][0] = 0;
     reductions[1][0][0] = 0;
 
-    for (int i = 1; i < MAXDEPTH; i++) {
+    for (int i = 1; i < 64; i++) {
         for (int j = 1; j < 64; j++) {
             reductions[0][i][j] = -0.25 + log(i) * log(j) / 2.25;
             reductions[1][i][j] = +1.00 + log(i) * log(j) / 2.00;
         }
     }
 
-    for (int depth = 0; depth < MAXDEPTH; depth++) {
+    for (int depth = 0; depth < 64; depth++) {
         lmp_margin[depth][0] = 1.5 + 0.5 * std::pow(depth, 2.0); // Not improving
         lmp_margin[depth][1] = 3.0 + 1.0 * std::pow(depth, 2.0); // improving
 
-        see_margin[depth][1] = -80 * depth; // Quiet moves
-        see_margin[depth][0] = -30 * depth * depth; // Non quiets
+        see_margin[depth][1] = -80.0 * std::pow(depth, 1.0); // Quiet moves
+        see_margin[depth][0] = -30.0 * std::pow(depth, 2.0); // Non quiets
 
     }
 }

--- a/src/position.h
+++ b/src/position.h
@@ -21,10 +21,6 @@
 #endif
 #define get_antidiagonal(sq) (get_rank[sq] + get_file[sq])
 
-extern int reductions[2][MAXDEPTH][64];
-extern int lmp_margin[MAXDEPTH][2];
-extern int see_margin[MAXDEPTH][2];
-
 struct BoardState {
     int castlePerm = 15;
     int capture = EMPTY;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -551,14 +551,14 @@ moves_loop:
             &&  bestScore > -MATE_FOUND) {
 
             // lmrDepth is the current depth minus the reduction the move would undergo in lmr, this is helpful because it helps us discriminate the bad moves with more accuracy
-            const int lmrDepth = std::max(0, depth - reductions[isQuiet][depth][std::min(totalMoves, 63)] + moveHistory / 16384);
+            const int lmrDepth = std::max(0, depth - reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)] + moveHistory / 16384);
 
             if (!skipQuiets) {
 
                 // Movecount pruning: if we searched enough moves and we are not in check we skip the rest
                 if (!pvNode
                     && !inCheck
-                    && totalMoves > lmp_margin[depth][improving]) {
+                    && totalMoves > lmp_margin[std::min(depth, 63)][improving]) {
                     skipQuiets = true;
                 }
 
@@ -572,14 +572,14 @@ moves_loop:
 
             // See pruning: prune all the moves that have a SEE score that is lower than our threshold
             if (    depth <= 8
-                && !SEE(pos, move, see_margin[lmrDepth][isQuiet]))
+                && !SEE(pos, move, see_margin[std::min(lmrDepth, 63)][isQuiet]))
                 continue;
         }
 
         int extension = 0;
         // Limit Extensions to try and curb search explosions
         if (ss->ply < td->RootDepth * 2) {
-            // Search extension
+            // Singular Extensions
             if (   !rootNode
                 &&  depth >= 7
                 &&  move == ttMove
@@ -637,7 +637,7 @@ moves_loop:
         if (totalMoves > 1 + pvNode && depth >= 3 && (isQuiet || !ttPv)) {
 
             // Get base reduction value
-            int depthReduction = reductions[isQuiet][depth][std::min(totalMoves, 63)];
+            int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];
 
             // Fuck
             if (cutNode)

--- a/src/search.h
+++ b/src/search.h
@@ -4,6 +4,10 @@
 #include "position.h"
 #include "uci.h"
 
+extern int reductions[2][64][64];
+extern int lmp_margin[64][2];
+extern int see_margin[64][2];
+
 struct SearchStack {
     // don't init, it will be init by search before entering the negamax method
     int excludedMove;

--- a/src/types.h
+++ b/src/types.h
@@ -14,7 +14,7 @@ using TTKey = uint16_t;
 // define poskey data type
 using ZobristKey = uint64_t;
 
-constexpr int MAXPLY = 128;
+constexpr int MAXPLY = 256;
 constexpr int MAXDEPTH = MAXPLY;
 constexpr int NOMOVE = 0;
 constexpr int MATE_SCORE = 32000;


### PR DESCRIPTION
Shrink some tables to reduce memory footprint

Elo   | 0.43 +- 1.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 48234 W: 11100 L: 11040 D: 26094
Penta | [162, 5452, 12806, 5558, 139]
https://chess.swehosting.se/test/6771/

Bench 7027744