### PR TITLE
Simplify SEE threshold

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -98,7 +98,7 @@ int NextMove(Movepicker* mp, const bool skip) {
             partialInsertionSort(&mp->moveList, mp->idx);
             const int move = mp->moveList.moves[mp->idx].move;
             const int score = mp->moveList.moves[mp->idx].score;
-            const int SEEThreshold = mp->movepickerType == SEARCH ? -score / 64 : -108;
+            const int SEEThreshold = -score / 64;
             ++mp->idx;
             if (move == mp->ttMove)
                 continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -632,7 +632,7 @@ moves_loop:
 
         // increment nodes count
         info->nodes++;
-        uint64_t nodesBeforeSearch = info->nodes;
+        const uint64_t nodesBeforeSearch = info->nodes;
         // Conditions to consider LMR. Calculate how much we should reduce the search depth.
         if (totalMoves > 1 + pvNode && depth >= 3 && (isQuiet || !ttPv)) {
 


### PR DESCRIPTION
Elo   | 1.04 +- 2.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 29794 W: 6860 L: 6771 D: 16163
Penta | [97, 3571, 7493, 3618, 118]

Elo   | 1.10 +- 2.00 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 27446 W: 5893 L: 5806 D: 15747
Penta | [14, 3157, 7295, 3242, 15]

Bench: 6519222