### PR TITLE
fix unsigned signed comparison warnings

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -58,7 +58,7 @@ void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const
         // Loop through all the quiet moves
         for (int i = 0; i < quietMoves->count; i++) {
             // For all the quiets moves that didn't cause a cut-off decrease the HH score
-            const int move = quietMoves->moves[i].move;
+            const auto move = quietMoves->moves[i].move;
             if (move == bestMove) continue;
             updateHHScore(pos, sd, move, -bonus);
             updateCHScore(ss, move, -bonus);
@@ -70,7 +70,7 @@ void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const
     }
     // For all the noisy moves that didn't cause a cut-off, even is the bestMove wasn't a noisy move, decrease the capthist score
     for (int i = 0; i < noisyMoves->count; i++) {
-        const int move = noisyMoves->moves[i].move;
+        const auto move = noisyMoves->moves[i].move;
         if (move == bestMove) continue;
         updateCapthistScore(pos, sd, move, -bonus);
     }

--- a/src/move.h
+++ b/src/move.h
@@ -5,7 +5,7 @@
 struct Position;
 
 struct ScoredMove {
-    int move;
+    Move move;
     int score;
 };
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -31,7 +31,7 @@ bool IsSquareAttacked(const Position* pos, const int square, const int side) {
 }
 
 // Check for move legality by generating the list of legal moves in a position and checking if that move is present
-bool MoveExists(Position* pos, const int move) {
+bool MoveExists(Position* pos, const Move move) {
     MoveList list;
     GenerateMoves(&list, pos, MOVEGEN_ALL);
 


### PR DESCRIPTION
This fixes 3 warnings due to the recent change to the Move type.

warning: comparison of integer expressions of different signedness