### PR TITLE
Simplify history and tweak some parameters

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -18,7 +18,7 @@ void ScoreMoves(Movepicker* mp) {
             int capturedPiece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
             // If we captured an empty piece this means the move is a non capturing promotion, we can pretend we captured a pawn to use a slot of the table that would've otherwise went unused (you can't capture pawns on the 1st/8th rank)
             if (capturedPiece == EMPTY) capturedPiece = PAWN;
-            moveList->moves[i].score = SEEValue[capturedPiece] * 32 + GetCapthistScore(pos, sd, move);
+            moveList->moves[i].score = SEEValue[capturedPiece] * 16 + GetCapthistScore(pos, sd, move);
         }
         else {
             moveList->moves[i].score = GetHistoryScore(pos, sd, move, ss);
@@ -97,7 +97,7 @@ Move NextMove(Movepicker* mp, const bool skip) {
             partialInsertionSort(&mp->moveList, mp->idx);
             const Move move = mp->moveList.moves[mp->idx].move;
             const int score = mp->moveList.moves[mp->idx].score;
-            const int SEEThreshold = -score / 64 + 139;
+            const int SEEThreshold = -score / 32 + 236;
             ++mp->idx;
             if (move == mp->ttMove)
                 continue;

--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -97,7 +97,7 @@ Move NextMove(Movepicker* mp, const bool skip) {
             partialInsertionSort(&mp->moveList, mp->idx);
             const Move move = mp->moveList.moves[mp->idx].move;
             const int score = mp->moveList.moves[mp->idx].score;
-            const int SEEThreshold = -score / 64 + 109;
+            const int SEEThreshold = -score / 64 + 139;
             ++mp->idx;
             if (move == mp->ttMove)
                 continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -553,7 +553,7 @@ moves_loop:
             &&  bestScore > -MATE_FOUND) {
 
             // lmrDepth is the current depth minus the reduction the move would undergo in lmr, this is helpful because it helps us discriminate the bad moves with more accuracy
-            const int lmrDepth = std::max(0, depth - reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)] + moveHistory / 16384);
+            const int lmrDepth = std::max(0, depth - reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)] + moveHistory / 8192);
 
             if (!skipQuiets) {
 
@@ -662,7 +662,7 @@ moves_loop:
                 depthReduction -= 1;
 
             // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
-            depthReduction -= moveHistory / 16384;
+            depthReduction -= moveHistory / 8192;
 
             // adjust the reduction so that we can't drop into Qsearch and to prevent extensions
             depthReduction = std::clamp(depthReduction, 0, newDepth - 1);


### PR DESCRIPTION
Elo   | 0.22 +- 1.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.69 (-2.94, 2.94) [0.00, 3.00]
Games | N: 62788 W: 14648 L: 14609 D: 33531
Penta | [229, 7464, 15966, 7509, 226]
https://chess.swehosting.se/test/6970/

Passed Non-reg: 
$ python3 sprt.py --wins 14648 --losses 14609 --draws 33531 --elo0 -3 --elo1 1
ELO: 0.216 +- 1.85 [-1.64, 2.07]
LLR: 2.97 [-3.0, 1.0] (-2.94, 2.94)
H1 Accepted

Bench 6566135