### PR TITLE
small changes

### DIFF
--- a/src/cuckoo.h
+++ b/src/cuckoo.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <array>
 #include <cstdint>
 #include "types.h"

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -5,7 +5,7 @@
 
 // This include breaks on non x86 target platforms
 #if defined(__INTEL_COMPILER) || defined(_MSC_VER)
-#include "xmmintrin.h"
+#include <xmmintrin.h>
 #endif
 
 #if defined(__linux__) && !defined(__ANDROID__)

--- a/src/uci.h
+++ b/src/uci.h
@@ -8,7 +8,7 @@ struct SearchInfo;
 
 struct UciOptions {
     uint64_t Hash = 16;
-    int MultiPV = 1;
+    static constexpr int MultiPV = 1;
     int Threads = 1;
 };
 


### PR DESCRIPTION
Make MultiPV static constexpr for now as it is unimplemented
Fix missing #pragma once in cuckoo.h
Fix including system header with "" instead of <> in ttable.cpp