### PR TITLE
Introduce correction history

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -104,7 +104,7 @@ int GetCapthistScore(const Position* pos, const SearchData* sd, const Move move)
 void updateCorrHistScore(const Position *pos, SearchData *sd, const int depth, const int diff) {
     int &entry = sd->corrHist[pos->side][pos->pawnKey % CORRHIST_SIZE];
     const int scaledDiff = diff * CORRHIST_VALUE_SCALE;
-    const int newWeight = std::min(depth * depth, 128);
+    const int newWeight = std::min(1 + depth, 16);
     assert(weight <= CORRHIST_WEIGHT_SCALE);
 
     entry = (entry * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -103,9 +103,9 @@ int GetCapthistScore(const Position* pos, const SearchData* sd, const Move move)
 
 void updateCorrHistScore(const Position *pos, SearchData *sd, const int depth, const int diff) {
     int &entry = sd->corrHist[pos->side][pos->pawnKey % CORRHIST_SIZE];
-    const int scaledDiff = diff * CORRHIST_VALUE_SCALE;
+    const int scaledDiff = diff * CORRHIST_GRAIN;
     const int newWeight = std::min(1 + depth, 16);
-    assert(weight <= CORRHIST_WEIGHT_SCALE);
+    assert(newWeight <= CORRHIST_WEIGHT_SCALE);
 
     entry = (entry * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;
     entry = std::clamp(entry, -CORRHIST_MAX, CORRHIST_MAX);
@@ -113,7 +113,7 @@ void updateCorrHistScore(const Position *pos, SearchData *sd, const int depth, c
 
 int adjustEvalWithCorrHist(const Position *pos, const SearchData *sd, const int rawEval) {
     const int &entry = sd->corrHist[pos->side][pos->pawnKey % CORRHIST_SIZE];
-    return rawEval + entry / CORRHIST_VALUE_SCALE;
+    return rawEval + entry / CORRHIST_GRAIN;
 }
 
 int GetHistoryScore(const Position* pos, const SearchData* sd, const Move move, const SearchStack* ss) {

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -113,7 +113,7 @@ void updateCorrHistScore(const Position *pos, SearchData *sd, const int depth, c
 
 int adjustEvalWithCorrHist(const Position *pos, const SearchData *sd, const int rawEval) {
     const int &entry = sd->corrHist[pos->side][pos->pawnKey % CORRHIST_SIZE];
-    return rawEval + entry / CORRHIST_GRAIN;
+    return std::clamp(rawEval + entry / CORRHIST_GRAIN, -MATE_FOUND + 1, MATE_FOUND - 1);
 }
 
 int GetHistoryScore(const Position* pos, const SearchData* sd, const Move move, const SearchStack* ss) {

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,4 +1,5 @@
 #include "history.h"
+#include <algorithm>
 #include <cstring>
 #include "position.h"
 #include "move.h"
@@ -15,8 +16,8 @@ int history_bonus(const int depth) {
 }
 
 void updateHHScore(const Position* pos, SearchData* sd, const Move move, int bonus) {
-    // Scale bonus to fix it in a [-8192;8192] range
-    const int scaledBonus = bonus - GetHHScore(pos, sd, move) * std::abs(bonus) / 8192;
+    // Scale bonus to fix it in a [-HH_MAX;HH_MAX] range
+    const int scaledBonus = bonus - GetHHScore(pos, sd, move) * std::abs(bonus) / HH_MAX;
     // Update move score
     sd->searchHistory[pos->side][FromTo(move)] += scaledBonus;
 }
@@ -30,15 +31,15 @@ void updateCHScore(SearchStack* ss, const Move move, const int bonus) {
 
 void updateSingleCHScore(SearchStack* ss, const Move move, const int bonus, const int offset) {
     if ((ss - offset)->move) {
-        // Scale bonus to fix it in a [-16384;16384] range
-        const int scaledBonus = bonus - GetSingleCHScore(ss, move, offset) * std::abs(bonus) / 16384;
+        // Scale bonus to fix it in a [-CH_MAX;CH_MAX] range
+        const int scaledBonus = bonus - GetSingleCHScore(ss, move, offset) * std::abs(bonus) / CH_MAX;
         (*((ss - offset)->contHistEntry))[PieceTo(move)] += scaledBonus;
     }
 }
 
 void updateCapthistScore(const Position* pos, SearchData* sd, const Move move, int bonus) {
-    // Scale bonus to fix it in a [-16384;16384] range
-    const int scaledBonus = bonus - GetCapthistScore(pos, sd, move) * std::abs(bonus) / 16384;
+    // Scale bonus to fix it in a [-CAPTHIST_MAX;CAPTHIST_MAX] range
+    const int scaledBonus = bonus - GetCapthistScore(pos, sd, move) * std::abs(bonus) / CAPTHIST_MAX;
     int capturedPiece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
     // If we captured an empty piece this means the move is a promotion, we can pretend we captured a pawn to use a slot of the table that would've otherwise went unused (you can't capture pawns on the 1st/8th rank)
     if (capturedPiece == EMPTY) capturedPiece = PAWN;
@@ -100,6 +101,21 @@ int GetCapthistScore(const Position* pos, const SearchData* sd, const Move move)
     return sd->captHist[PieceTo(move)][capturedPiece];
 }
 
+void updateCorrHistScore(const Position *pos, SearchData *sd, const int depth, const int diff) {
+    int &entry = sd->corrHist[pos->side][pos->pawnKey % CORRHIST_SIZE];
+    const int scaledDiff = diff * CORRHIST_VALUE_SCALE;
+    const int newWeight = std::min(depth * depth, 128);
+    assert(weight <= CORRHIST_WEIGHT_SCALE);
+
+    entry = (entry * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;
+    entry = std::clamp(entry, -CORRHIST_MAX, CORRHIST_MAX);
+}
+
+int adjustEvalWithCorrHist(const Position *pos, const SearchData *sd, const int rawEval) {
+    const int &entry = sd->corrHist[pos->side][pos->pawnKey % CORRHIST_SIZE];
+    return rawEval + entry / CORRHIST_VALUE_SCALE;
+}
+
 int GetHistoryScore(const Position* pos, const SearchData* sd, const Move move, const SearchStack* ss) {
     if (!isTactical(move))
         return GetHHScore(pos, sd, move) + GetCHScore(ss, move);
@@ -112,4 +128,5 @@ void CleanHistories(SearchData* sd) {
     std::memset(sd->searchHistory, 0, sizeof(sd->searchHistory));
     std::memset(sd->contHist, 0, sizeof(sd->contHist));
     std::memset(sd->captHist, 0, sizeof(sd->captHist));
+    std::memset(sd->corrHist, 0, sizeof(sd->corrHist));
 }

--- a/src/history.h
+++ b/src/history.h
@@ -7,6 +7,14 @@ struct SearchData;
 struct SearchStack;
 struct MoveList;
 
+constexpr int HH_MAX = 8192;
+constexpr int CH_MAX = 16384;
+constexpr int CAPTHIST_MAX = 16384;
+constexpr int CORRHIST_WEIGHT_SCALE = 512;
+constexpr int CORRHIST_VALUE_SCALE = 256;
+constexpr int CORRHIST_SIZE = 16384;
+constexpr int CORRHIST_MAX = CORRHIST_VALUE_SCALE * 256;
+
 // Functions used to update the history heuristics
 void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const int depth, const Move bestMove, const MoveList* quietMoves, const MoveList* noisyMoves);
 // Fuction that returns the history bonus
@@ -24,3 +32,7 @@ void updateHHScore(const Position* pos, SearchData* sd, const Move move, int bon
 void updateCHScore(SearchStack* ss, const Move move, const int bonus);
 void updateCapthistScore(const Position* pos, SearchData* sd, const Move move, int bonus);
 void updateSingleCHScore(SearchStack* ss, const Move move, const int bonus, const int offset);
+
+// Corrhist stuff
+void updateCorrHistScore(const Position *pos, SearchData *sd, const int depth, const int diff);
+int  adjustEvalWithCorrHist(const Position *pos, const SearchData *sd, const int rawEval);

--- a/src/history.h
+++ b/src/history.h
@@ -12,7 +12,7 @@ constexpr int CH_MAX = 16384;
 constexpr int CAPTHIST_MAX = 16384;
 constexpr int CORRHIST_WEIGHT_SCALE = 256;
 constexpr int CORRHIST_VALUE_SCALE = 256;
-constexpr int CORRHIST_SIZE = 16384;
+constexpr int CORRHIST_SIZE = 4096;
 constexpr int CORRHIST_MAX = CORRHIST_VALUE_SCALE * 256;
 
 // Functions used to update the history heuristics

--- a/src/history.h
+++ b/src/history.h
@@ -12,8 +12,8 @@ constexpr int CH_MAX = 16384;
 constexpr int CAPTHIST_MAX = 16384;
 constexpr int CORRHIST_WEIGHT_SCALE = 256;
 constexpr int CORRHIST_GRAIN = 256;
-constexpr int CORRHIST_SIZE = 131072;
-constexpr int CORRHIST_MAX = CORRHIST_GRAIN * 256;
+constexpr int CORRHIST_SIZE = 16384;
+constexpr int CORRHIST_MAX = CORRHIST_GRAIN * 32;
 
 // Functions used to update the history heuristics
 void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const int depth, const Move bestMove, const MoveList* quietMoves, const MoveList* noisyMoves);

--- a/src/history.h
+++ b/src/history.h
@@ -10,7 +10,7 @@ struct MoveList;
 constexpr int HH_MAX = 8192;
 constexpr int CH_MAX = 16384;
 constexpr int CAPTHIST_MAX = 16384;
-constexpr int CORRHIST_WEIGHT_SCALE = 512;
+constexpr int CORRHIST_WEIGHT_SCALE = 256;
 constexpr int CORRHIST_VALUE_SCALE = 256;
 constexpr int CORRHIST_SIZE = 16384;
 constexpr int CORRHIST_MAX = CORRHIST_VALUE_SCALE * 256;

--- a/src/history.h
+++ b/src/history.h
@@ -11,9 +11,9 @@ constexpr int HH_MAX = 8192;
 constexpr int CH_MAX = 16384;
 constexpr int CAPTHIST_MAX = 16384;
 constexpr int CORRHIST_WEIGHT_SCALE = 256;
-constexpr int CORRHIST_VALUE_SCALE = 256;
-constexpr int CORRHIST_SIZE = 4096;
-constexpr int CORRHIST_MAX = CORRHIST_VALUE_SCALE * 256;
+constexpr int CORRHIST_GRAIN = 256;
+constexpr int CORRHIST_SIZE = 131072;
+constexpr int CORRHIST_MAX = CORRHIST_GRAIN * 256;
 
 // Functions used to update the history heuristics
 void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const int depth, const Move bestMove, const MoveList* quietMoves, const MoveList* noisyMoves);

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -89,6 +89,8 @@ void PrintBoard(const Position* pos) {
 
     std::cout << "position key: " << pos->posKey << std::endl;
 
+    std::cout << "pawn key: " << pos->pawnKey << std::endl;
+
     std::cout << "Fen: " << GetFen(pos) << "\n\n";
 }
 

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -21,6 +21,8 @@ void ClearPiece(const int piece, const int from, Position* pos) {
     pop_bit(pos->occupancies[color], from);
     pos->pieces[from] = EMPTY;
     HashKey(pos->posKey, PieceKeys[piece][from]);
+    if(GetPieceType(piece) == PAWN)
+        HashKey(pos->pawnKey, PieceKeys[piece][from]);
 }
 
 template void AddPiece<false>(const int piece, const int to, Position* pos);
@@ -36,6 +38,8 @@ void AddPiece(const int piece, const int to, Position* pos) {
     set_bit(pos->occupancies[color], to);
     pos->pieces[to] = piece;
     HashKey(pos->posKey, PieceKeys[piece][to]);
+    if(GetPieceType(piece) == PAWN)
+        HashKey(pos->pawnKey, PieceKeys[piece][to]);
 }
 
 // Move a piece from the [to] square to the [from] square, the UPDATE params determines whether we want to update the NNUE weights or not
@@ -324,6 +328,7 @@ void MakeMove(const Move move, Position* pos) {
         pos->checkMask = fullCheckmask;
     // Make sure a freshly generated zobrist key matches the one we are incrementally updating
     assert(pos->posKey == GeneratePosKey(pos));
+    assert(pos->pawnKey == GeneratePawnKey(pos));
 }
 
 void UnmakeMove(const Move move, Position* pos) {

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -4,6 +4,10 @@
 #include "position.h"
 #include "init.h"
 
+void inline HashKey(Position* pos, ZobristKey key) {
+    pos->posKey ^= key;
+}
+
 template void ClearPiece<false>(const int piece, const int to, Position* pos);
 template void ClearPiece<true>(const int piece, const int to, Position* pos);
 
@@ -49,10 +53,6 @@ void UpdateCastlingPerms(Position* pos, int source_square, int target_square) {
     pos->castleperm &= castling_rights[target_square];
     // Xor the new one
     HashKey(pos, CastleKeys[pos->GetCastlingPerm()]);
-}
-
-void inline HashKey(Position* pos, ZobristKey key) {
-    pos->posKey ^= key;
 }
 
 template <bool UPDATE>

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -402,8 +402,8 @@ void UnmakeMove(const Move move, Position* pos) {
     // change side
     pos->ChangeSide();
 
-    // restore zobrist key (done at the end to avoid overwriting the value while
-    // moving pieces back to their place)
+    // restore zobrist key (done at the end to avoid overwriting the value while moving pieces back to their place)
+    // we don't need to do the same for the pawn key because the unmake function correctly restores it already
     pos->posKey = pos->played_positions.back();
     pos->played_positions.pop_back();
 }

--- a/src/makemove.h
+++ b/src/makemove.h
@@ -12,8 +12,6 @@ void AddPiece(const int piece, const int to, Position* pos);
 
 void UpdateCastlingPerms(Position* pos, int source_square, int target_square);
 
-void HashKey(Position* pos, ZobristKey key);
-
 template <bool UPDATE>
 void MakeMove(const Move move, Position* pos);
 // Reverts the previously played move

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -68,6 +68,19 @@ ZobristKey GeneratePosKey(const Position* pos) {
     return finalkey;
 }
 
+// Generates zobrist key (for only the pawns) from scratch
+ZobristKey GeneratePawnKey(const Position* pos) {
+    Bitboard pawnKey = 0;
+    for (int sq = 0; sq < 64; ++sq) {
+        // get piece on that square
+        const int piece = pos->PieceOn(sq);
+        if (piece == WP || piece == BP) {
+            finalkey ^= PieceKeys[piece][sq];
+        }
+    }
+    return pawnKey;
+}
+
 // parse FEN string
 void ParseFen(const std::string& command, Position* pos) {
 
@@ -194,6 +207,7 @@ void ParseFen(const std::string& command, Position* pos) {
         pos->occupancies[BLACK] |= pos->bitboards[piece];
 
     pos->posKey = GeneratePosKey(pos);
+    pos->pawnKey = GeneratePawnKey(pos);
 
     // Update pinmasks and checkers
     UpdatePinsAndCheckers(pos, pos->side);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -75,7 +75,7 @@ ZobristKey GeneratePawnKey(const Position* pos) {
         // get piece on that square
         const int piece = pos->PieceOn(sq);
         if (piece == WP || piece == BP) {
-            finalkey ^= PieceKeys[piece][sq];
+            pawnKey ^= PieceKeys[piece][sq];
         }
     }
     return pawnKey;

--- a/src/position.h
+++ b/src/position.h
@@ -47,6 +47,7 @@ public:
     int castleperm = 0;
     // unique  hashkey  that encodes a board position
     ZobristKey posKey = 0ULL;
+    ZobristKey pawnKey = 0ULL;
     // stores the state of the board  rollback purposes
     int historyStackHead = 0;
     BoardState    history[MAXPLY];
@@ -164,8 +165,8 @@ constexpr char ascii_pieces[13] = "PNBRQKpnbrqk";
 // NNUE
 extern NNUE nnue;
 
-// Generates zobrist key from scratch
 [[nodiscard]] ZobristKey GeneratePosKey(const Position* pos);
+[[nodiscard]] ZobristKey GeneratePawnKey(const Position* pos);
 // parse FEN string
 void ParseFen(const std::string& command, Position* pos);
 // Get fen string from board

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -349,6 +349,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
     const bool inCheck = pos->checkers;
     const bool rootNode = (ss->ply == 0);
     int eval;
+    int rawEval;
     bool improving;
     int score = -MAXSCORE;
     TTEntry tte;
@@ -426,7 +427,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
 
     // If we are in check or searching a singular extension we avoid pruning before the move loop
     if (inCheck || excludedMove) {
-        eval = SCORE_NONE;
+        eval = rawEval = SCORE_NONE;
         if (!excludedMove) ss->staticEval = SCORE_NONE;
         improving = false;
         goto moves_loop;
@@ -435,7 +436,8 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
     // get an evaluation of the position:
     if (ttHit) {
         // If the value in the TT is valid we use that, otherwise we call the static evaluation function
-        eval = ss->staticEval = tte.eval != SCORE_NONE ? tte.eval : EvalPosition(pos);
+        rawEval = tte.eval != SCORE_NONE ? tte.eval : EvalPosition(pos);
+        eval = ss->staticEval = rawEval;
 
         // We can also use the tt score as a more accurate form of eval
         if (    ttScore != SCORE_NONE
@@ -446,10 +448,11 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
     }
     else {
         // If we don't have anything in the TT we have to call evalposition
-        eval = ss->staticEval = EvalPosition(pos);
+        rawEval = EvalPosition(pos);
+        eval = ss->staticEval = rawEval;
         if (!excludedMove)
             // Save the eval into the TT
-            StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, eval, HFNONE, 0, pvNode, ttPv);
+            StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, rawEval, HFNONE, 0, pvNode, ttPv);
     }
 
     // Improving is a very important modifier to many heuristics. It checks if our static eval has improved since our last move.
@@ -756,7 +759,7 @@ moves_loop:
     int bound = bestScore >= beta ? HFLOWER : alpha != old_alpha ? HFEXACT : HFUPPER;
 
     if (!excludedMove)
-        StoreTTEntry(pos->posKey, MoveToTT(bestMove), ScoreToTT(bestScore, ss->ply), ss->staticEval, bound, depth, pvNode, ttPv);
+        StoreTTEntry(pos->posKey, MoveToTT(bestMove), ScoreToTT(bestScore, ss->ply), rawEval, bound, depth, pvNode, ttPv);
 
     return bestScore;
 }
@@ -771,6 +774,7 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
     // tte is an TT entry, it will store the values fetched from the TT
     TTEntry tte;
     int bestScore;
+    int rawEval;
 
     // check if more than Maxtime passed and we have to stop
     if (td->id == 0 && TimeOver(&td->info)) {
@@ -810,14 +814,15 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
     const bool ttPv = pvNode || (ttHit && FormerPV(tte.ageBoundPV));
 
     if (inCheck) {
-        ss->staticEval = SCORE_NONE;
+        rawEval = ss->staticEval = SCORE_NONE;
         bestScore = -MAXSCORE;
     }
     // If we have a ttHit with a valid eval use that
     else if (ttHit) {
 
         // If the value in the TT is valid we use that, otherwise we call the static evaluation function
-        ss->staticEval = bestScore = tte.eval != SCORE_NONE ? tte.eval : EvalPosition(pos);
+        rawEval = tte.eval != SCORE_NONE ? tte.eval : EvalPosition(pos);
+        ss->staticEval = bestScore = rawEval;
 
         // We can also use the TT score as a more accurate form of eval
         if (    ttScore != SCORE_NONE
@@ -828,9 +833,10 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
     }
     // If we don't have any useful info in the TT just call Evalpos
     else {
-        bestScore = ss->staticEval = EvalPosition(pos);
+        rawEval = EvalPosition(pos);
+        bestScore = ss->staticEval = rawEval;
         // Save the eval into the TT
-        StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, ss->staticEval, HFNONE, 0, pvNode, ttPv);
+        StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, rawEval, HFNONE, 0, pvNode, ttPv);
     }
 
     // Stand pat
@@ -908,7 +914,7 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
     // Set the TT bound based on whether we failed high, for qsearch we never use the exact bound
     int bound = bestScore >= beta ? HFLOWER : HFUPPER;
 
-    StoreTTEntry(pos->posKey, MoveToTT(bestmove), ScoreToTT(bestScore, ss->ply), ss->staticEval, bound, 0, pvNode, ttPv);
+    StoreTTEntry(pos->posKey, MoveToTT(bestmove), ScoreToTT(bestScore, ss->ply), rawEval, bound, 0, pvNode, ttPv);
 
     return bestScore;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -761,9 +761,9 @@ moves_loop:
     if (!excludedMove) {
         if (    !inCheck
             && (!bestMove || !isTactical(bestMove))
-            &&  !(bound == HFLOWER && bestScore <= ss->staticEval)
-            &&  !(bound == HFUPPER && bestScore >= ss->staticEval)) {
-            updateCorrHistScore(pos, sd, depth, bestScore - ss->staticEval);
+            &&  !(bound == HFLOWER && bestScore <= rawEval)
+            &&  !(bound == HFUPPER && bestScore >= rawEval)) {
+            updateCorrHistScore(pos, sd, depth, bestScore - rawEval);
         }
         StoreTTEntry(pos->posKey, MoveToTT(bestMove), ScoreToTT(bestScore, ss->ply), rawEval, bound, depth, pvNode, ttPv);
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -761,9 +761,9 @@ moves_loop:
     if (!excludedMove) {
         if (    !inCheck
             && (!bestMove || !isTactical(bestMove))
-            &&  !(bound == HFLOWER && bestScore <= rawEval)
-            &&  !(bound == HFUPPER && bestScore >= rawEval)) {
-            updateCorrHistScore(pos, sd, depth, bestScore - rawEval);
+            &&  !(bound == HFLOWER && bestScore <= ss->staticEval)
+            &&  !(bound == HFUPPER && bestScore >= ss->staticEval)) {
+            updateCorrHistScore(pos, sd, depth, bestScore - ss->staticEval);
         }
         StoreTTEntry(pos->posKey, MoveToTT(bestMove), ScoreToTT(bestScore, ss->ply), rawEval, bound, depth, pvNode, ttPv);
     }

--- a/src/search.h
+++ b/src/search.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include "history.h"
 #include "position.h"
 #include "uci.h"
 
@@ -24,6 +25,7 @@ struct SearchData {
     int captHist[12 * 64][6] = {};
     int counterMoves[64 * 64] = {};
     int contHist[12 * 64][12 * 64] = {};
+    int corrHist[2][CORRHIST_SIZE] = {};
 };
 
 struct PvTable {

--- a/src/types.h
+++ b/src/types.h
@@ -3,7 +3,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.0.4"
+#define NAME "Alexandria-7.0.5"
 
 #define start_position "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 


### PR DESCRIPTION
Inspired by approaches from Seer and Caissa. Thanks to Vizvezdenec for giving some tips on the implementation

STC:
Elo   | 11.29 +- 4.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 6034 W: 1557 L: 1361 D: 3116
Penta | [20, 659, 1481, 819, 38]
https://chess.swehosting.se/test/6994/

LTC:
Elo   | 12.40 +- 4.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 4988 W: 1166 L: 988 D: 2834
Penta | [1, 499, 1318, 673, 3]
https://chess.swehosting.se/test/7006/

Bench 6324052