### PR TITLE
Combine 2 correction history patches

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -12,7 +12,7 @@ GetScore: this is simply a getter for a specific entry of the history table
 */
 
 int history_bonus(const int depth) {
-    return std::min(16 * (depth + 1) * (depth + 1), 1200);
+    return std::min(16 * depth * depth + 32 * depth + 16, 1200);
 }
 
 void updateHHScore(const Position* pos, SearchData* sd, const Move move, int bonus) {
@@ -104,7 +104,7 @@ int GetCapthistScore(const Position* pos, const SearchData* sd, const Move move)
 void updateCorrHistScore(const Position *pos, SearchData *sd, const int depth, const int diff) {
     int &entry = sd->corrHist[pos->side][pos->pawnKey % CORRHIST_SIZE];
     const int scaledDiff = diff * CORRHIST_GRAIN;
-    const int newWeight = std::min(1 + depth, 16);
+    const int newWeight = std::min(depth * depth + 2 * depth + 1, 128);
     assert(newWeight <= CORRHIST_WEIGHT_SCALE);
 
     entry = (entry * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;

--- a/src/history.h
+++ b/src/history.h
@@ -10,10 +10,10 @@ struct MoveList;
 constexpr int HH_MAX = 8192;
 constexpr int CH_MAX = 16384;
 constexpr int CAPTHIST_MAX = 16384;
-constexpr int CORRHIST_WEIGHT_SCALE = 256;
+constexpr int CORRHIST_WEIGHT_SCALE = 1024;
 constexpr int CORRHIST_GRAIN = 256;
 constexpr int CORRHIST_SIZE = 16384;
-constexpr int CORRHIST_MAX = CORRHIST_GRAIN * 32;
+constexpr int CORRHIST_MAX = 16384;
 
 // Functions used to update the history heuristics
 void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const int depth, const Move bestMove, const MoveList* quietMoves, const MoveList* noisyMoves);

--- a/src/types.h
+++ b/src/types.h
@@ -3,7 +3,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.0.6"
+#define NAME "Alexandria-7.0.7"
 
 #define start_position "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 


### PR DESCRIPTION
1. Increase correction history limits
2. Scale correction history updates quadratically based on depth

Passed STC:
Elo   | 2.70 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32136 W: 7815 L: 7565 D: 16756
Penta | [131, 3801, 7974, 4011, 151]
https://chess.swehosting.se/test/7128/

Passed LTC:
Elo   | 3.20 +- 2.20 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23590 W: 5374 L: 5157 D: 13059
Penta | [21, 2710, 6127, 2905, 32]
https://chess.swehosting.se/test/7142/

Bench 6118297