### PR TITLE
Remove Unnecessary Branching

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -460,9 +460,8 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         // If we don't have anything in the TT we have to call evalposition
         rawEval = EvalPosition(pos);
         eval = ss->staticEval = adjustEvalWithCorrHist(pos, sd, rawEval);
-        if (!excludedMove)
-            // Save the eval into the TT
-            StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, rawEval, HFNONE, 0, pvNode, ttPv);
+        // Save the eval into the TT
+        StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, rawEval, HFNONE, 0, pvNode, ttPv);
     }
 
     // Improving is a very important modifier to many heuristics. It checks if our static eval has improved since our last move.


### PR DESCRIPTION
This condition is unnecessary due to the earlier `else if (excludedMove)`. No functional changes. Credits to @liamt19 for pointing this out on SF Discord.

Bench: 6118297