### PR TITLE
Remove most lmr tweaks for non quiet moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -657,28 +657,31 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];
 
-            // Fuck
-            if (cutNode)
-                depthReduction += 2;
+            if(isQuiet) {
 
-            // Reduce more if we are not improving
-            if (!improving)
-                depthReduction += 1;
+                // Fuck
+                if (cutNode)
+                    depthReduction += 2;
 
-            // Reduce less if the move is a refutation
-            if (move == mp.killer || move == mp.counter)
-                depthReduction -= 1;
+                // Reduce more if we are not improving
+                if (!improving)
+                    depthReduction += 1;
 
-            // Reduce less if we have been on the PV
-            if (ttPv)
-                depthReduction -= 1 + cutNode;
+                // Reduce less if the move is a refutation
+                if (move == mp.killer || move == mp.counter)
+                    depthReduction -= 1;
 
-            // Decrease the reduction for moves that give check
-            if (pos->checkers)
-                depthReduction -= 1;
+                // Reduce less if we have been on the PV
+                if (ttPv)
+                    depthReduction -= 1 + cutNode;
 
-            // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
-            depthReduction -= moveHistory / 8192;
+                // Decrease the reduction for moves that give check
+                if (pos->checkers)
+                    depthReduction -= 1;
+
+                // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
+                depthReduction -= moveHistory / 8192;
+            }
 
             // adjust the reduction so that we can't drop into Qsearch and to prevent extensions
             depthReduction = std::clamp(depthReduction, 0, newDepth - 1);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -657,6 +657,10 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];
 
+            // Reduce less if we have been on the PV
+            if (ttPv)
+                depthReduction -= 1 + cutNode;
+
             if(isQuiet) {
                 // Fuck
                 if (cutNode)
@@ -669,7 +673,6 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
                 // Reduce less if the move is a refutation
                 if (move == mp.killer || move == mp.counter)
                     depthReduction -= 1;
-
 
                 // Decrease the reduction for moves that give check
                 if (pos->checkers)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -657,10 +657,6 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];
 
-            // Reduce less if we have been on the PV
-            if (ttPv)
-                depthReduction -= 1 + cutNode;
-
             if(isQuiet) {
                 // Fuck
                 if (cutNode)
@@ -680,6 +676,11 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
 
                 // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
                 depthReduction -= moveHistory / 8192;
+
+                // Reduce less if we have been on the PV
+                if (ttPv)
+                    depthReduction -= 1 + cutNode;
+
             }
 
             // adjust the reduction so that we can't drop into Qsearch and to prevent extensions

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -657,8 +657,10 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];
 
-            if(isQuiet) {
+            // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
+            depthReduction -= moveHistory / 8192;
 
+            if(isQuiet) {
                 // Fuck
                 if (cutNode)
                     depthReduction += 2;
@@ -678,9 +680,6 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
                 // Decrease the reduction for moves that give check
                 if (pos->checkers)
                     depthReduction -= 1;
-
-                // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
-                depthReduction -= moveHistory / 8192;
             }
 
             // adjust the reduction so that we can't drop into Qsearch and to prevent extensions

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -657,9 +657,6 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];
 
-            // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
-            depthReduction -= moveHistory / 8192;
-
             if(isQuiet) {
                 // Fuck
                 if (cutNode)
@@ -673,13 +670,13 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
                 if (move == mp.killer || move == mp.counter)
                     depthReduction -= 1;
 
-                // Reduce less if we have been on the PV
-                if (ttPv)
-                    depthReduction -= 1 + cutNode;
 
                 // Decrease the reduction for moves that give check
                 if (pos->checkers)
                     depthReduction -= 1;
+
+                // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
+                depthReduction -= moveHistory / 8192;
             }
 
             // adjust the reduction so that we can't drop into Qsearch and to prevent extensions

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -657,10 +657,11 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];
 
+            // Fuck
+            if (cutNode)
+                depthReduction += 2;
+
             if(isQuiet) {
-                // Fuck
-                if (cutNode)
-                    depthReduction += 2;
 
                 // Reduce more if we are not improving
                 if (!improving)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -662,7 +662,6 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
                 depthReduction += 2;
 
             if(isQuiet) {
-
                 // Reduce more if we are not improving
                 if (!improving)
                     depthReduction += 1;
@@ -681,7 +680,6 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
                 // Reduce less if we have been on the PV
                 if (ttPv)
                     depthReduction -= 1 + cutNode;
-
             }
 
             // adjust the reduction so that we can't drop into Qsearch and to prevent extensions


### PR DESCRIPTION
This isn't striclty a simplification, it actually adds code, adding an additional branch in the code that evaluates what the lmr reduction should be. 
The reason i believe this to be desireable under non regr bounds is making it clear in the code that most of the tweaks don't contribute Elo when applied to non quiet moves. Special tweaks for noisy moves might gain Elo and this opens the doors to testing them with gainer bounds 