### PR TITLE
Tweak tactical LMR with history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -656,11 +656,11 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];
 
-            // Fuck
-            if (cutNode)
-                depthReduction += 2;
+            if (isQuiet) {
+                // Fuck
+                if (cutNode)
+                    depthReduction += 2;
 
-            if(isQuiet) {
                 // Reduce more if we are not improving
                 if (!improving)
                     depthReduction += 1;
@@ -673,12 +673,20 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
                 if (pos->checkers)
                     depthReduction -= 1;
 
-                // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
-                depthReduction -= moveHistory / 8192;
-
                 // Reduce less if we have been on the PV
                 if (ttPv)
                     depthReduction -= 1 + cutNode;
+
+                // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
+                depthReduction -= moveHistory / 8192;
+            }
+            else {
+                // Fuck
+                if (cutNode)
+                    depthReduction += 2;
+
+                // Decrease the reduction for moves that have a good history score and increase it for moves with a bad score
+                depthReduction -= moveHistory / 6144;
             }
 
             // adjust the reduction so that we can't drop into Qsearch and to prevent extensions

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.0.10"
+#define NAME "Alexandria-7.0.11"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
STC:
Elo   | 1.71 +- 1.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 65442 W: 15818 L: 15495 D: 34129
Penta | [265, 7639, 16585, 7972, 260]
https://chess.swehosting.se/test/7305/

LTC:
Elo   | 3.97 +- 2.51 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 17940 W: 4116 L: 3911 D: 9913
Penta | [20, 2006, 4714, 2209, 21]
https://chess.swehosting.se/test/7309/

Bench 5701669