### PR TITLE
Introduction evaluation grain of 16

### DIFF
--- a/src/eval.h
+++ b/src/eval.h
@@ -49,6 +49,7 @@ static inline int ScaleMaterial(const Position* pos, int eval) {
     int eval = EvalPositionRaw(pos);
     eval = ScaleMaterial(pos, eval);
     eval = eval * (200 - pos->Get50mrCounter()) / 200;
+    eval = (eval / 16) * 16 - 1 + (pos->posKey & 0x2);
     // Clamp eval to avoid it somehow being a mate score
     eval = std::clamp(eval, -MATE_FOUND + 1, MATE_FOUND - 1);
     return eval;

--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -1,7 +1,6 @@
 #include "movepicker.h"
 #include "move.h"
 #include "movegen.h"
-#include "piece_data.h"
 #include "history.h"
 
 // ScoreMoves takes a list of move as an argument and assigns a score to each move

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.0.11"
+#define NAME "Alexandria-7.0.12"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
Original idea (and promising test results) from SF, see: https://github.com/official-stockfish/Stockfish/pull/5449
Appeared incredibly neutral st STC but the fishtest results warranted a speculative LTC, passed the speculative LTC
Elo   | 2.20 +- 1.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 40008 W: 9092 L: 8839 D: 22077
Penta | [41, 4619, 10439, 4856, 49]

Bench: 5647256