### PR TITLE
Simplify !inCheck condition for LMP

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -574,7 +574,6 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
 
                 // Movecount pruning: if we searched enough moves and we are not in check we skip the rest
                 if (!pvNode
-                    && !inCheck
                     && totalMoves > lmp_margin[std::min(depth, 63)][improving]) {
                     skipQuiets = true;
                 }


### PR DESCRIPTION
passed gainer bounds stc, passed the palm reading test

Elo   | 3.12 +- 2.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 25834 W: 6233 L: 6001 D: 13600
Penta | [73, 3049, 6465, 3233, 97]
Bench: 5844491