### PR TITLE
Remove depth guard from LMP

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -587,8 +587,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             }
 
             // See pruning: prune all the moves that have a SEE score that is lower than our threshold
-            if (    depth <= 8
-                && !SEE(pos, move, see_margin[std::min(lmrDepth, 63)][isQuiet]))
+            if (!SEE(pos, move, see_margin[std::min(lmrDepth, 63)][isQuiet]))
                 continue;
         }
 


### PR DESCRIPTION
passed gainer bounds STC
Elo   | 4.75 +- 2.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15304 W: 3761 L: 3552 D: 7991
Penta | [64, 1710, 3888, 1933, 57]

passed simplification bounds LTC
Elo   | 1.10 +- 1.91 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.3175 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 30858 W: 6999 L: 6901 D: 16958
Penta | [34, 3552, 8149, 3670, 24]

Bench: 5211058