### PR TITLE
Add getters for all board state variables

### DIFF
--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -312,9 +312,9 @@ void MakeMove(const Move move, Position* pos) {
     // Update pinmasks and checkers
     UpdatePinsAndCheckers(pos, pos->side);
     // If we are in check get the squares between the checking piece and the king
-    if (pos->checkers) {
+    if (pos->getCheckers()) {
         const int kingSquare = KingSQ(pos, pos->side);
-        const int pieceLocation = GetLsbIndex(pos->checkers);
+        const int pieceLocation = GetLsbIndex(pos->getCheckers());
         pos->checkMask = (1ULL << pieceLocation) | RayBetween(pieceLocation, kingSquare);
     }
     else
@@ -370,7 +370,7 @@ void UnmakeMove(const Move move, Position* pos) {
     if (capture) {
         const int SOUTH = pos->side == WHITE ? -8 : 8;
         // Retrieve the captured piece we have to restore
-        const int piececap = pos->history[pos->historyStackHead].capture;
+        const int piececap = pos->getCapturedPiece();
         const int capturedPieceLocation = enpass ? targetSquare + SOUTH : targetSquare;
         AddPiece<false>(piececap, capturedPieceLocation, pos);
     }

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -135,7 +135,7 @@ void MakeEp(const Move move, Position* pos) {
     AddPiece<UPDATE>(piece, targetSquare, pos);
 
     // Reset EP square
-    assert(GetEpSquare(pos) != no_sq);
+    assert(pos->getEpSquare() != no_sq);
     HashKey(pos->posKey, enpassant_keys[pos->getEpSquare()]);
     pos->enPas = no_sq;
 }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -213,9 +213,9 @@ void ParseFen(const std::string& command, Position* pos) {
     UpdatePinsAndCheckers(pos, pos->side);
 
     // If we are in check get the squares between the checking piece and the king
-    if (pos->checkers) {
+    if (pos->getCheckers()) {
         const int kingSquare = KingSQ(pos, pos->side);
-        const int pieceLocation = GetLsbIndex(pos->checkers);
+        const int pieceLocation = GetLsbIndex(pos->getCheckers());
         pos->checkMask = (1ULL << pieceLocation) | RayBetween(pieceLocation, kingSquare);
     }
     else
@@ -464,10 +464,10 @@ void saveBoardState(Position* pos) {
     pos->history[pos->historyStackHead].fiftyMove = pos->fiftyMove;
     pos->history[pos->historyStackHead].enPas = pos->enPas;
     pos->history[pos->historyStackHead].castlePerm = pos->castleperm;
-    pos->history[pos->historyStackHead].plyFromNull = pos->plyFromNull;
-    pos->history[pos->historyStackHead].checkers = pos->checkers;
-    pos->history[pos->historyStackHead].checkMask = pos->checkMask;
-    pos->history[pos->historyStackHead].pinned = pos->pinned;
+    pos->history[pos->historyStackHead].plyFromNull = pos->getPlyFromNull();
+    pos->history[pos->historyStackHead].checkers = pos->getCheckers();
+    pos->history[pos->historyStackHead].checkMask = pos->getCheckmask();
+    pos->history[pos->historyStackHead].pinned = pos->getPinnedMask();
 }
 
 void restorePreviousBoardState(Position* pos)
@@ -483,7 +483,7 @@ void restorePreviousBoardState(Position* pos)
 
 bool hasGameCycle(Position* pos, int ply) {
 
-    int end = std::min(pos->get50MrCounter(), pos->plyFromNull);
+    int end = std::min(pos->get50MrCounter(), pos->getPlyFromNull());
 
     if (end < 3)
         return false;

--- a/src/position.h
+++ b/src/position.h
@@ -106,6 +106,26 @@ public:
         return enPas;
     }
 
+    [[nodiscard]] inline int getPlyFromNull() const {
+        return plyFromNull;
+    }
+
+    [[nodiscard]] inline Bitboard getCheckers() const {
+        return checkers;
+    }
+
+    [[nodiscard]] inline Bitboard getCheckmask() const {
+        return checkMask;
+    }
+
+    [[nodiscard]] inline Bitboard getPinnedMask() const {
+        return pinned;
+    }
+
+    [[nodiscard]] inline int getCapturedPiece() const {
+        return history[historyStackHead].capture;
+    }
+
     inline void ChangeSide() {
         side ^= 1;
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -22,7 +22,7 @@ static bool IsRepetition(const Position* pos) {
     assert(pos->hisPly >= pos->fiftyMove);
     int counter = 0;
     // How many moves back should we look at most, aka our distance to the last irreversible move
-    int distance = std::min(pos->get50MrCounter(), pos->plyFromNull);
+    int distance = std::min(pos->get50MrCounter(), pos->getPlyFromNull());
     // Get the point our search should start from
     int startingPoint = pos->played_positions.size();
     // Scan backwards from the first position where a repetition is possible (4 half moves ago) for at most distance steps
@@ -48,7 +48,7 @@ static bool Is50MrDraw(Position* pos) {
     if (pos->get50MrCounter() >= 100) {
 
         // If there's no risk we are being checkmated return true
-        if (!pos->checkers)
+        if (!pos->getCheckers())
             return true;
 
         // if we are in check make sure it's not checkmate 
@@ -356,7 +356,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
     PvTable* pvTable = &td->pvTable;
 
     // Initialize the node
-    const bool inCheck = pos->checkers;
+    const bool inCheck = pos->getCheckers();
     const bool rootNode = (ss->ply == 0);
     int eval;
     int rawEval;
@@ -667,7 +667,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
                     depthReduction -= 1;
 
                 // Decrease the reduction for moves that give check
-                if (pos->checkers)
+                if (pos->getCheckers())
                     depthReduction -= 1;
 
                 // Reduce less if we have been on the PV
@@ -795,7 +795,7 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
     Position* pos = &td->pos;
     SearchData* sd = &td->sd;
     SearchInfo* info = &td->info;
-    const bool inCheck = pos->checkers;
+    const bool inCheck = pos->getCheckers();
     // tte is an TT entry, it will store the values fetched from the TT
     TTEntry tte;
     int bestScore;


### PR DESCRIPTION
Elo   | -0.48 +- 2.28 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 0.09 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 25550 W: 6385 L: 6420 D: 12745
Penta | [185, 2939, 6548, 2932, 171]

Bench: 5211058