### PR TITLE
Fail saved RFP

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -484,7 +484,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         if (   depth < 10
             && abs(eval) < MATE_FOUND
             && eval - 91 * (depth - improving) >= beta)
-            return eval;
+            return eval - 91 * (depth - improving);
 
         // Null move pruning: If our position is so good that we can give the opponent a free move and still fail high,
         // return early. At higher depth we do a reduced search with null move pruning disabled (ie verification search)

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.0.14"
+#define NAME "Alexandria-7.0.15"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
Elo   | 4.92 +- 2.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14632 W: 3558 L: 3351 D: 7723
Penta | [37, 1665, 3746, 1790, 78]

Elo   | 1.17 +- 0.92 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 131098 W: 29414 L: 28972 D: 72712
Penta | [81, 15190, 34604, 15554, 120]

Bench: 5169868