### PR TITLE
Tweak NMP

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -503,7 +503,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         // to prevent falling into zugzwangs.
         if (   eval >= ss->staticEval
             && eval >= beta
-            && ss->staticEval >= beta - 24 * depth + 130
+            && ss->staticEval >= beta - 24 * depth + 170
             && (ss - 1)->move != NOMOVE
             && depth >= nmpDepth()
             && ss->ply >= td->nmpPlies

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -503,7 +503,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         // to prevent falling into zugzwangs.
         if (   eval >= ss->staticEval
             && eval >= beta
-            && ss->staticEval >= beta - 24 * depth + 230
+            && ss->staticEval >= beta - 24 * depth + 170
             && (ss - 1)->move != NOMOVE
             && depth >= nmpDepth()
             && ss->ply >= td->nmpPlies

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -503,6 +503,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         // to prevent falling into zugzwangs.
         if (   eval >= ss->staticEval
             && eval >= beta
+            && ss->staticEval >= beta - 24 * depth + 130
             && (ss - 1)->move != NOMOVE
             && depth >= nmpDepth()
             && ss->ply >= td->nmpPlies

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -503,7 +503,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         // to prevent falling into zugzwangs.
         if (   eval >= ss->staticEval
             && eval >= beta
-            && ss->staticEval >= beta - 24 * depth + 170
+            && ss->staticEval >= beta - 24 * depth + 230
             && (ss - 1)->move != NOMOVE
             && depth >= nmpDepth()
             && ss->ply >= td->nmpPlies

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -503,7 +503,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         // to prevent falling into zugzwangs.
         if (   eval >= ss->staticEval
             && eval >= beta
-            && ss->staticEval >= beta - 24 * depth + 170
+            && ss->staticEval >= beta - 30 * depth + 170
             && (ss - 1)->move != NOMOVE
             && depth >= nmpDepth()
             && ss->ply >= td->nmpPlies

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.0.19"
+#define NAME "Alexandria-7.0.20"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
Passed STC:
Elo   | 2.37 +- 1.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
Games | N: 39310 W: 9480 L: 9212 D: 20618
Penta | [134, 4677, 9782, 4911, 151]
https://chess.swehosting.se/test/8338/

Passed LTC:
Elo   | 1.63 +- 1.31 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 65324 W: 14626 L: 14320 D: 36378
Penta | [59, 7535, 17174, 7829, 65]
https://chess.swehosting.se/test/8343/