### PR TITLE
Remove nonPawns guard for forward pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -668,7 +668,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         info->nodes++;
         const uint64_t nodesBeforeSearch = info->nodes;
         // Conditions to consider LMR. Calculate how much we should reduce the search depth.
-        if (totalMoves > 1 + pvNode + (ss->ply < 7 || ss->ply > 24) && depth >= 3 && (isQuiet || !ttPv)) {
+        if (totalMoves > 1 + pvNode && depth >= 3 && (isQuiet || !ttPv)) {
 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -584,7 +584,6 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
 
         const int moveHistory = GetHistoryScore(pos, sd, move, ss, false);
         if (   !rootNode
-            &&  BoardHasNonPawns(pos, pos->side)
             &&  bestScore > -MATE_FOUND) {
 
             // lmrDepth is the current depth minus the reduction the move would undergo in lmr, this is helpful because it helps us discriminate the bad moves with more accuracy
@@ -669,7 +668,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         info->nodes++;
         const uint64_t nodesBeforeSearch = info->nodes;
         // Conditions to consider LMR. Calculate how much we should reduce the search depth.
-        if (totalMoves > 1 + pvNode && depth >= 3 && (isQuiet || !ttPv)) {
+        if (totalMoves > 1 + pvNode + (ss->ply < 7 || ss->ply > 24) && depth >= 3 && (isQuiet || !ttPv)) {
 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];


### PR DESCRIPTION
STC:
Elo   | 3.67 +- 3.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 10310 W: 2481 L: 2372 D: 5457
Penta | [20, 1068, 2879, 1159, 29]
LTC:
Elo   | 0.68 +- 1.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 35812 W: 7980 L: 7910 D: 19922
Penta | [20, 3820, 10158, 3886, 22]

Bench: 5389308
