### PR TITLE
Simplify QS futility pruning conditions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -920,8 +920,7 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
 
         // Futility pruning. If static eval is far below alpha, only search moves that win material.
         if (    bestScore > -MATE_FOUND
-            && !inCheck
-            &&  BoardHasNonPawns(pos, pos->side)) {
+            && !inCheck) {
             const int futilityBase = ss->staticEval + 192;
             if (futilityBase <= alpha && !SEE(pos, move, 1)) {
                 bestScore = std::max(futilityBase, bestScore);


### PR DESCRIPTION
Elo   | 2.98 +- 3.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 12360 W: 3007 L: 2901 D: 6452
Penta | [32, 1286, 3455, 1358, 49]

Elo   | -0.11 +- 1.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.63 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 64422 W: 14381 L: 14401 D: 35640
Penta | [37, 6500, 19156, 6482, 36]

Bench: 6083794