### PR TITLE
Remove pv node guard from lmp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -601,8 +601,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             if (!skipQuiets) {
 
                 // Movecount pruning: if we searched enough moves and we are not in check we skip the rest
-                if (!pvNode
-                    && totalMoves > lmp_margin[std::min(depth, 63)][improving]) {
+                if (totalMoves > lmp_margin[std::min(depth, 63)][improving]) {
                     skipQuiets = true;
                 }
 


### PR DESCRIPTION
failed STC:
Elo   | -2.05 +- 2.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.30 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 23570 W: 5593 L: 5732 D: 12245
Penta | [86, 2911, 5920, 2792, 76]

passed LTC:
Elo   | 0.38 +- 1.50 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 49844 W: 11468 L: 11414 D: 26962
Penta | [24, 5879, 13073, 5911, 35]

Bench: 6899697