### PR TITLE
Probcut

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -41,7 +41,7 @@ void partialInsertionSort(MoveList* moveList, const int moveNum) {
     std::swap(moveList->moves[moveNum], moveList->moves[bestNum]);
 }
 
-void InitMP(Movepicker* mp, Position* pos, SearchData* sd, SearchStack* ss, const Move ttMove, const MovepickerType movepickerType, const bool rootNode) {
+void InitMP(Movepicker* mp, Position* pos, SearchData* sd, SearchStack* ss, const Move ttMove, const int SEEThreshold, const MovepickerType movepickerType, const bool rootNode) {
 
     const Move killer = ss->searchKiller;
     const Move counter = sd->counterMoves[FromTo((ss - 1)->move)];
@@ -56,6 +56,7 @@ void InitMP(Movepicker* mp, Position* pos, SearchData* sd, SearchStack* ss, cons
     mp->stage = mp->ttMove ? PICK_TT : GEN_NOISY;
     mp->killer = killer != ttMove ? killer : NOMOVE;
     mp->counter = counter != ttMove && counter != killer ? counter : NOMOVE;
+    mp->SEEThreshold = SEEThreshold;
 }
 
 Move NextMove(Movepicker* mp, const bool skip) {
@@ -73,16 +74,27 @@ Move NextMove(Movepicker* mp, const bool skip) {
             && mp->stage > PICK_GOOD_NOISY) {
             return NOMOVE;
         }
+
+        // In probcut, we only search captures that pass the threshold
+        if (   mp->movepickerType == PROBCUT
+               && mp->stage > PICK_GOOD_NOISY) {
+            return NOMOVE;
+        }
     }
     switch (mp->stage) {
     case PICK_TT:
         ++mp->stage;
-        // If we are in qsearch and not in check, skip quiet TT moves
-        if (mp->movepickerType == QSEARCH && skip && !isTactical(mp->ttMove))
-            goto top;
+            // If we are in qsearch and not in check, or we are in probcut, skip quiet TT moves
+            if ((mp->movepickerType == PROBCUT || (mp->movepickerType == QSEARCH && skip))
+                && !isTactical(mp->ttMove))
+                goto top;
 
         // If the TT move if not pseudo legal we skip it too
         if (!IsPseudoLegal(mp->pos, mp->ttMove))
+            goto top;
+
+        // If we are in probcut and the TT move does not pass SEE, we skip it
+        if (mp->movepickerType == PROBCUT && !SEE(mp->pos, mp->ttMove, -1))
             goto top;
 
         return mp->ttMove;
@@ -98,7 +110,7 @@ Move NextMove(Movepicker* mp, const bool skip) {
             partialInsertionSort(&mp->moveList, mp->idx);
             const Move move = mp->moveList.moves[mp->idx].move;
             const int score = mp->moveList.moves[mp->idx].score;
-            const int SEEThreshold = -score / 32 + 236;
+            const int SEEThreshold =  mp->movepickerType == PROBCUT ? mp->SEEThreshold : -score / 32 + 236;
             ++mp->idx;
             if (move == mp->ttMove)
                 continue;

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -18,7 +18,8 @@ enum {
 
 enum MovepickerType : uint8_t {
     SEARCH,
-    QSEARCH
+    QSEARCH,
+    PROBCUT
 };
 
 struct Movepicker {
@@ -33,9 +34,10 @@ struct Movepicker {
     Move counter;
     int idx;
     int stage;
+    int SEEThreshold;
     bool rootNode;
 };
 
-void InitMP(Movepicker* mp, Position* pos, SearchData* sd, SearchStack* ss, const Move ttMove, const MovepickerType movepickerType, const bool rootNode);
+void InitMP(Movepicker* mp, Position* pos, SearchData* sd, SearchStack* ss, const Move ttMove, const int SEEThreshold, const MovepickerType movepickerType, const bool rootNode);
 Move NextMove(Movepicker* mp, const bool skip);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -560,6 +560,53 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         }
     }
 
+    const int pcBeta = beta + 300 - 50 * improving;
+    if (  !pvNode
+        && depth > 4
+        && abs(beta) < MATE_FOUND
+        && (ttScore == SCORE_NONE || (ttBound & HFLOWER))
+        && (ttScore == SCORE_NONE || tte.depth < depth - 3 || ttScore >= pcBeta))
+    {
+        Movepicker mp;
+        Move move;
+        InitMP(&mp, pos, sd, ss, NOMOVE, pcBeta - ss->staticEval, PROBCUT, rootNode);
+        while ((move = NextMove(&mp, true)) != NOMOVE) {
+
+            if (!IsLegal(pos, move))
+                continue;
+
+            if (move == excludedMove)
+                continue;
+
+            // Speculative prefetch of the TT entry
+            TTPrefetch(keyAfter(pos, move));
+
+            ss->move = move;
+            ss->contHistEntry = &sd->contHist[PieceTo(move)];
+
+            // increment nodes count
+            info->nodes++;
+
+            // Play the move
+            MakeMove<true>(move, pos);
+
+            int pcScore = -Quiescence<false>(-pcBeta, -pcBeta + 1, td, ss + 1);
+            if (pcScore >= pcBeta)
+                pcScore = -Negamax<false>(-pcBeta, -pcBeta + 1, depth - 3 - 1,
+                                          !cutNode, td, ss + 1);
+
+            // Take move back
+            UnmakeMove(move, pos);
+
+            if (pcScore >= pcBeta) {
+                StoreTTEntry(pos->posKey, MoveToTT(move),
+                             ScoreToTT(pcScore, ss->ply), rawEval, HFLOWER,
+                             depth - 3, pvNode, ttPv);
+                return pcScore;
+            }
+        }
+    }
+
     // IIR by Ed Schroder (That i find out about in Berserk source code)
     // http://talkchess.com/forum3/viewtopic.php?f=7&t=74769&sid=64085e3396554f0fba414404445b3120
     // https://github.com/jhonnold/berserk/blob/dd1678c278412898561d40a31a7bd08d49565636/src/search.c#L379
@@ -576,7 +623,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
     bool skipQuiets = false;
 
     Movepicker mp;
-    InitMP(&mp, pos, sd, ss, ttMove, SEARCH, rootNode);
+    InitMP(&mp, pos, sd, ss, ttMove, SCORE_NONE,SEARCH, rootNode);
 
     // Keep track of the played quiet and noisy moves
     MoveList quietMoves, noisyMoves;
@@ -905,7 +952,7 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
 
     Movepicker mp;
     // If we aren't in check we generate just the captures, otherwise we generate all the moves
-    InitMP(&mp, pos, sd, ss, ttMove, QSEARCH, false);
+    InitMP(&mp, pos, sd, ss, ttMove, SCORE_NONE,QSEARCH, false);
 
     Move bestmove = NOMOVE;
     Move move;

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.1.1"
+#define NAME "Alexandria-7.1.2"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
Passed STC:
Elo   | 3.06 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 26128 W: 6413 L: 6183 D: 13532
Penta | [56, 3086, 6567, 3282, 73]
https://chess.swehosting.se/test/9209/

Passed LTC:
Elo   | 1.77 +- 1.42 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 54994 W: 12760 L: 12480 D: 29754
Penta | [32, 6291, 14566, 6581, 27]
https://chess.swehosting.se/test/9211/

bench 7235310