### PR TITLE
Simplify avx2 sum reduction

### DIFF
--- a/src/simd.h
+++ b/src/simd.h
@@ -34,22 +34,10 @@ inline vepi16  vec_mullo_epi16(const vepi16 vec0, const vepi16 vec1) { return _m
 inline vepi32  vec_madd_epi16 (const vepi16 vec0, const vepi16 vec1) { return _mm256_madd_epi16(vec0, vec1); }
 inline vepi32  vec_add_epi32  (const vepi32 vec0, const vepi32 vec1) { return _mm256_add_epi32(vec0, vec1); }
 inline int32_t vec_reduce_add_epi32(const vepi32 vec) {
-    // Split the __m256i into 2 __m128i vectors, and add them together
-    __m128i lower128 = _mm256_castsi256_si128(vec);
-    __m128i upper128 = _mm256_extracti128_si256(vec, 1);
-    __m128i sum128   = _mm_add_epi32(lower128, upper128);
-
-    // Store the high 64 bits of sum128 in the low 64 bits of this vector,
-    // then add them together (only the lowest 64 bits are relevant)
-    __m128i upper64 = _mm_unpackhi_epi64(sum128, sum128);
-    __m128i sum64   = _mm_add_epi32(upper64, sum128);
-
-    // Store the high 32 bits of the relevant part of sum64 in the low 32 bits of the vector,
-    // and then add them together (only the lowest 32 bits are relevant)
-    __m128i upper32 = _mm_shuffle_epi32(sum64, 1);
-    __m128i sum32   = _mm_add_epi32(upper32, sum64);
-
-    // Return the bottom 32 bits of sum32
-    return _mm_cvtsi128_si32(sum32);
+    __m256i v1 = _mm256_hadd_epi32(vec, vec); // 0, 2, 4, 6, 1, 3, 5, 7
+    __m256i v2 = _mm256_hadd_epi32(v1, v1); // 0, 4, 1, 5, 2, 6, 3, 7
+    // Step 2: Extract the final result
+    int result = _mm256_extract_epi32(v2, 0) + _mm256_extract_epi32(v2, 4);
+    return result;
 }
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.1.4"
+#define NAME "Alexandria-7.1.5"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.1.5"
+#define NAME "Alexandria-7.1.4"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
Elo   | 0.86 +- 1.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 31590 W: 7597 L: 7519 D: 16474
Penta | [64, 3309, 8971, 3387, 64]