### PR TITLE
Speed up finny table refreshes

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.1.5"
+#define NAME "Alexandria-7.1.6"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
Elo   | 3.35 +- 2.30 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23658 W: 6190 L: 5962 D: 11506
Penta | [121, 2573, 6239, 2749, 147]
https://chess.swehosting.se/test/9335/

bench 8476323