### PR TITLE
Guard less moves from lmr

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -734,7 +734,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         info->nodes++;
         const uint64_t nodesBeforeSearch = info->nodes;
         // Conditions to consider LMR. Calculate how much we should reduce the search depth.
-        if (totalMoves > 1 + pvNode + rootNode && depth >= 3 && (isQuiet || !ttPv)) {
+        if (totalMoves > 1  && depth >= 3 && (isQuiet || !ttPv)) {
 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -734,7 +734,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         info->nodes++;
         const uint64_t nodesBeforeSearch = info->nodes;
         // Conditions to consider LMR. Calculate how much we should reduce the search depth.
-        if (totalMoves > 1 + pvNode && depth >= 3 && (isQuiet || !ttPv)) {
+        if (totalMoves > 1 + pvNode + rootNode && depth >= 3 && (isQuiet || !ttPv)) {
 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -734,7 +734,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         info->nodes++;
         const uint64_t nodesBeforeSearch = info->nodes;
         // Conditions to consider LMR. Calculate how much we should reduce the search depth.
-        if (totalMoves > 1  && depth >= 3 && (isQuiet || !ttPv)) {
+        if (totalMoves > 1 && depth >= 3 && (isQuiet || !ttPv)) {
 
             // Get base reduction value
             int depthReduction = reductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)];

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.1.7"
+#define NAME "Alexandria-7.1.8"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
Passed STC:
Elo   | 1.99 +- 1.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 49622 W: 12120 L: 11836 D: 25666
Penta | [139, 5862, 12570, 6056, 184]

likely at least neutral at LTC:
Elo: 0.98 (-2.39 / +2.39) [-1.41 to 3.36]
nElo: 2.03 (-4.96 / +4.96) [-2.93 to 6.98]
Gamepairs Elo: 1.47 (-4.75 / +4.75) [-3.27 to 6.22]
Normalized Pair Elo: 1.06
LLR: 3.5367