### PR TITLE
Tweak SE parameters

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -12,7 +12,6 @@ struct SearchStack {
     Move move;
     int ply;
     Move searchKiller;
-    int doubleExtensions;
     int (*contHistEntry)[12 * 64];
 };
 


### PR DESCRIPTION
Elo   | 3.32 +- 2.45 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 17980 W: 4224 L: 4052 D: 9704
Penta | [5, 1994, 4821, 2164, 6]
https://chess.swehosting.se/test/9507/

Bench 8669143