### PR TITLE
Improve compiler optimization

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ EVALFILE     = nn.net
 CXX         := g++
 TARGET      := Alexandria
 WARNINGS     = -Wall -Wcast-qual -Wextra -Wshadow -Wdouble-promotion -Wformat=2 -Wnull-dereference -Wlogical-op -Wold-style-cast -Wundef -pedantic
-CXXFLAGS    := -funroll-loops -O3 -flto -fno-exceptions -std=gnu++2a -DNDEBUG $(WARNINGS)
+CXXFLAGS    := -funroll-loops -O3 -flto -flto-partition=one -fno-exceptions -std=gnu++2a -DNDEBUG $(WARNINGS)
 NATIVE       = -march=native
 AVX2FLAGS    = -DUSE_AVX2 -DUSE_SIMD -mavx2 -mbmi -mfma
 BMI2FLAGS    = -DUSE_AVX2 -DUSE_SIMD -mavx2 -mbmi -mbmi2 -mfma


### PR DESCRIPTION
Elo   | 1.80 +- 1.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 3.00]
Games | N: 56644 W: 13964 L: 13671 D: 29009
Penta | [185, 6140, 15379, 6433, 185]

Bench: 10727485