### PR TITLE
Reduce stack usage

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -90,7 +90,7 @@ void updateCapthistScore(const Position* pos, SearchData* sd, const Move move, i
 }
 
 // Update all histories
-void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const int depth, const Move bestMove, const MoveList* quietMoves, const MoveList* noisyMoves, const bool rootNode) {
+void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const int depth, const Move bestMove, const StackMoveList* quietMoves, const StackMoveList* noisyMoves, const bool rootNode) {
     const int bonus = history_bonus(depth);
     const int capthist_bonus = capthistory_bonus(depth);
     const int conthist_bonus = conthistory_bonus(depth);
@@ -109,7 +109,7 @@ void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const
         // Loop through all the quiet moves
         for (int i = 0; i < quietMoves->count; i++) {
             // For all the quiets moves that didn't cause a cut-off decrease the HH score
-            const Move move = quietMoves->moves[i].move;
+            const Move move = quietMoves->moves[i];
             if (move == bestMove) continue;
             updateHHScore(pos, sd, move, -malus);
             updateCHScore(ss, move, -conthist_malus);
@@ -123,7 +123,7 @@ void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const
     }
     // For all the noisy moves that didn't cause a cut-off, even is the bestMove wasn't a noisy move, decrease the capthist score
     for (int i = 0; i < noisyMoves->count; i++) {
-        const Move move = noisyMoves->moves[i].move;
+        const Move move = noisyMoves->moves[i];
         if (move == bestMove) continue;
         updateCapthistScore(pos, sd, move, -capthist_malus);
     }

--- a/src/history.h
+++ b/src/history.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "types.h"
+#include "move.h"
 
 struct Position;
 struct SearchData;
@@ -17,7 +18,7 @@ constexpr int CORRHIST_SIZE = 16384;
 constexpr int CORRHIST_MAX = 16384;
 
 // Functions used to update the history heuristics
-void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const int depth, const Move bestMove, const MoveList* quietMoves, const MoveList* noisyMoves, const bool rootNode);
+void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const int depth, const Move bestMove, const StackMoveList* quietMoves, const StackMoveList* noisyMoves, const bool rootNode);
 // Fuction that returns the history bonus
 int history_bonus(const int depth);
 int history_malus(const int depth);

--- a/src/move.h
+++ b/src/move.h
@@ -15,6 +15,18 @@ struct MoveList {
     int count = 0;
 };
 
+// move list structure
+struct StackMoveList {
+    Move moves[64];
+    int count = 0;
+    void addMove(Move move){
+        if(count < 64) {
+            moves[count] = move;
+            count++;
+        }
+    }
+};
+
 enum class Movetype {
     Quiet, doublePush, KSCastle,
     QSCastle, Capture, enPassant,

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -641,7 +641,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
     InitMP(&mp, pos, sd, ss, ttMove, SCORE_NONE,SEARCH, rootNode);
 
     // Keep track of the played quiet and noisy moves
-    MoveList quietMoves, noisyMoves;
+    StackMoveList quietMoves, noisyMoves;
 
     // loop over moves within a movelist
     while ((move = NextMove(&mp, skipQuiets)) != NOMOVE) {
@@ -732,7 +732,10 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         MakeMove<true>(move, pos);
         ss->contHistEntry = &sd->contHist[PieceTo(move)];
         // Add any played move to the matching list
-        AddMove(move, isQuiet ? &quietMoves : &noisyMoves);
+        if(isQuiet)
+            quietMoves.addMove(move);
+        else
+            noisyMoves.addMove(move);
 
         // increment nodes count
         info->nodes++;

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-7.1.11"
+#define NAME "Alexandria-7.1.12"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
Fixes a rare chkstk crash on windows.
Passed STC non regr:
Elo   | 1.42 +- 1.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 5.20 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 40020 W: 9805 L: 9641 D: 20574
Penta | [111, 4218, 11200, 4358, 123]