### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/alexandria.yml
+++ b/.github/workflows/alexandria.yml
@@ -53,15 +53,15 @@ jobs:
           install: mingw-w64-${{matrix.config.msys_env}} make git expect
 
       - name: download net
-        run: curl -sOL https://github.com/PGG106/Alexandria-networks/releases/download/net01/1536x16.net
+        run: curl -sOL https://github.com/PGG106/Alexandria-networks/releases/latest/download/nn.net
 
       - name: make
         if: runner.os == 'Linux'
-        run: make build=debug EVALFILE=1536x16.net -j
+        run: make build=debug EVALFILE=nn.net -j
 
       - name: make build windows
         if: runner.os == 'Windows'
-        run: make build=release EVALFILE=1536x16.net -j
+        run: make build=release EVALFILE=nn.net -j
 
       - name: Bench
         run: |


### PR DESCRIPTION
Fixes #509
Note: All Alexandria-networks releases from now on must have net name as nn.net. cc @PGG106 

Bench 9330832