### PR TITLE
Use material value based scaling over phase based scaling

### DIFF
--- a/src/eval.h
+++ b/src/eval.h
@@ -24,7 +24,7 @@
     return false;
 }
 
-[[nodiscard]] static inline int ScaleMaterial(const Position* pos, int eval) {
+[[nodiscard]] static inline int getMaterialValue(const Position* pos) {
 
     int pawns = CountBits(GetPieceBB(pos, PAWN));
     int knights = CountBits(GetPieceBB(pos, KNIGHT));
@@ -32,7 +32,12 @@
     int rooks = CountBits(GetPieceBB(pos, ROOK));
     int queens = CountBits(GetPieceBB(pos, QUEEN));
 
-    const int scale = 700 + (pawns * SEEValue[PAWN] + knights * SEEValue[KNIGHT] + bishops * SEEValue[BISHOP] + rooks * SEEValue[ROOK] + queens * SEEValue[QUEEN]) / 32;
+    return (pawns * 100 + knights * 422 + bishops * 422 + rooks * 642 + queens * 1015) / 32;
+}
+
+[[nodiscard]] static inline int ScaleMaterial(const Position* pos, int eval) {
+
+    const int scale = 700 + getMaterialValue(pos);
 
     return (eval * scale) / 1024;
 }

--- a/src/eval.h
+++ b/src/eval.h
@@ -25,13 +25,16 @@
 }
 
 [[nodiscard]] static inline int ScaleMaterial(const Position* pos, int eval) {
-    const int knights = CountBits(GetPieceBB(pos, KNIGHT));
-    const int bishops = CountBits(GetPieceBB(pos, BISHOP));
-    const int rooks = CountBits(GetPieceBB(pos, ROOK));
-    const int queens = CountBits(GetPieceBB(pos, QUEEN));
-    const int phase = std::min(3 * knights + 3 * bishops + 5 * rooks + 10 * queens, 64);
-    // Scale between [0.75, 1.00]
-    return eval * (192 + phase) / 256;
+
+    int pawns = CountBits(GetPieceBB(pos, PAWN));
+    int knights = CountBits(GetPieceBB(pos, KNIGHT));
+    int bishops = CountBits(GetPieceBB(pos, BISHOP));
+    int rooks = CountBits(GetPieceBB(pos, ROOK));
+    int queens = CountBits(GetPieceBB(pos, QUEEN));
+
+    const int scale = 700 + (pawns * SEEValue[PAWN] + knights * SEEValue[KNIGHT] + bishops * SEEValue[BISHOP] + rooks * SEEValue[ROOK] + queens * SEEValue[QUEEN]) / 32;
+
+    return (eval * scale) / 1024;
 }
 
 [[nodiscard]] inline int EvalPositionRaw(Position* pos) {

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-8.0.0"
+#define NAME "Alexandria-8.0.1"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
Elo   | 2.55 +- 1.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33716 W: 8303 L: 8056 D: 17357
Penta | [97, 3934, 8559, 4161, 107]

Elo   | 1.74 +- 1.40 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 55766 W: 12865 L: 12585 D: 30316
Penta | [30, 6330, 14886, 6604, 33]

Bench: 9973272