### PR TITLE
Simplify tm, use maxtime bound as the hardtime bound

### DIFF
--- a/src/time_manager.cpp
+++ b/src/time_manager.cpp
@@ -16,21 +16,9 @@ void Optimum(SearchInfo* info, int time, int inc) {
         info->stoptimeMax = info->starttime + time;
         info->stoptimeOpt = info->starttime + time;
     }
-    // else If we received a movestogo parameter we use total_time/movestogo
-    else if (info->timeset && info->movestogo != -1) {
-        // Divide the time you have left for how many moves you have to play
-        const auto basetime = time / info->movestogo;
-        // Never use more than 76% of the total time left for a single move
-        const auto maxtime = 0.76 * time;
-        // optime is the time we use to stop if we just cleared a depth
-        const auto optime = std::min((optTimeMultiplier() / 100.0) * basetime, maxtime);
-        info->stoptimeMax = info->starttime + maxtime;
-        info->stoptimeBaseOpt = optime;
-        info->stoptimeOpt = info->starttime + info->stoptimeBaseOpt;
-    }
-    // else if we received wtime/btime we calculate an over and upper bound for the time usage based on fixed coefficients
-    else if (info->timeset) {
-        int basetime = time * (baseMultiplier() / 1000.0) + inc * (incMultiplier() / 100.0);
+    else {
+        // Divide the time you have left for how many moves you have to play, if it's an X+Y time control assume 20ish moves to go and add a fraction of the increment
+        const auto basetime = info->movestogo != -1 ? time / info->movestogo : time * (baseMultiplier() / 1000.0) + inc * (incMultiplier() / 100.0);
         // Never use more than 76% of the total time left for a single move
         const auto maxtime = 0.76 * time;
         // optime is the time we use to stop if we just cleared a depth

--- a/src/time_manager.cpp
+++ b/src/time_manager.cpp
@@ -21,11 +21,9 @@ void Optimum(SearchInfo* info, int time, int inc) {
         // Divide the time you have left for how many moves you have to play
         const auto basetime = time / info->movestogo;
         // Never use more than 76% of the total time left for a single move
-        const auto maxtimeBound = 0.76 * time;
+        const auto maxtime = 0.76 * time;
         // optime is the time we use to stop if we just cleared a depth
-        const auto optime = std::min((optTimeMultiplier() / 100.0) * basetime, maxtimeBound);
-        // maxtime is the absolute maximum time we can spend on a search (unless it is bigger than the bound)
-        const auto maxtime = std::min((maxTimeMultiplier() / 100.0) * basetime, maxtimeBound);
+        const auto optime = std::min((optTimeMultiplier() / 100.0) * basetime, maxtime);
         info->stoptimeMax = info->starttime + maxtime;
         info->stoptimeBaseOpt = optime;
         info->stoptimeOpt = info->starttime + info->stoptimeBaseOpt;
@@ -34,11 +32,9 @@ void Optimum(SearchInfo* info, int time, int inc) {
     else if (info->timeset) {
         int basetime = time * (baseMultiplier() / 1000.0) + inc * (incMultiplier() / 100.0);
         // Never use more than 76% of the total time left for a single move
-        const auto maxtimeBound = 0.76 * time;
+        const auto maxtime = 0.76 * time;
         // optime is the time we use to stop if we just cleared a depth
-        const auto optime = std::min((optTimeMultiplier() / 100.0) * basetime, maxtimeBound);
-        // maxtime is the absolute maximum time we can spend on a search (unless it is bigger than the bound)
-        const auto maxtime = std::min((maxTimeMultiplier() / 100.0) * basetime, maxtimeBound);
+        const auto optime = std::min((optTimeMultiplier() / 100.0) * basetime, maxtime);
         info->stoptimeMax = info->starttime + maxtime;
         info->stoptimeBaseOpt = optime;
         info->stoptimeOpt = info->starttime + info->stoptimeBaseOpt;

--- a/src/tune.h
+++ b/src/tune.h
@@ -91,7 +91,6 @@ inline bool updateTuneVariable(std::string tune_variable_name, int value)
 TUNE_PARAM(baseMultiplier, 51, 20, 150, 7, 0.002)
 TUNE_PARAM(incMultiplier, 85, 50, 150, 5, 0.002)
 TUNE_PARAM(optTimeMultiplier, 76, 50, 90, 2, 0.002)
-TUNE_PARAM(maxTimeMultiplier, 323, 100, 500, 20, 0.002)
 
 // Bestmove stability
 TUNE_PARAM(bmScale1, 238, 50, 300, 10, 0.002)

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-8.0.1"
+#define NAME "Alexandria-8.0.2"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
Passed non regression STC:
Elo   | 10.67 +- 5.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 3942 W: 1021 L: 900 D: 2021
Penta | [15, 374, 1065, 509, 8]

Passed non regression LTC:
Elo   | 5.66 +- 3.90 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 6748 W: 1609 L: 1499 D: 3640
Penta | [2, 683, 1896, 789, 4]


Passed gainer bounds STC:
Elo   | 4.26 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16564 W: 4126 L: 3923 D: 8515
Penta | [41, 1746, 4519, 1921, 55]

Passed gainer bounds LTC:
Elo   | 5.84 +- 3.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10292 W: 2418 L: 2245 D: 5629
Penta | [6, 961, 3037, 1138, 4]
