### PR TITLE
Reintroduce draw score randomization

### DIFF
--- a/src/bench.cpp
+++ b/src/bench.cpp
@@ -59,8 +59,7 @@ const char* benchmarkfens[52] = {
     "2rr2k1/1p4bp/p1q1p1p1/4Pp1n/2PB4/1PN3P1/P3Q2P/2RR2K1 w - f6 0 20",
     "3br1k1/p1pn3p/1p3n2/5pNq/2P1p3/1PN3PP/P2Q1PB1/4R1K1 w - - 0 23",
     "2r2b2/5p2/5k2/p1r1pP2/P2pB3/1P3P2/K1P3R1/7R w - - 23 93" ,
-    "8/P6p/2K1q1pk/2Q5/4p3/8/7P/8 w - - 4 44",
-    "7k/8/7P/5B2/5K2/8/8/8 b - - 0 175"
+    "8/P6p/2K1q1pk/2Q5/4p3/8/7P/8 w - - 4 44"
 };
 
 void StartBench(int depth) {

--- a/src/bench.cpp
+++ b/src/bench.cpp
@@ -71,7 +71,7 @@ void StartBench(int depth) {
     InitTT(64);
     InitNewGame(td);
     auto start = std::chrono::steady_clock::now();
-    for (int positions = 0; positions < 52; positions++) {
+    for (int positions = 0; positions < 51; positions++) {
         ParseFen(benchmarkfens[positions], &td->pos);
         std::cout << "\nPosition: " << positions + 1 << " fen: " << benchmarkfens[positions] << std::endl;
         RootSearch(depth, td, &uciOptions);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -401,7 +401,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
     if (!rootNode) {
         // If position is a draw return a draw score
         if (IsDraw(pos))
-            return 0;
+            return (info->nodes & 2) - 1;
 
         // Upcoming repetition detection
         if (alpha < 0 && hasGameCycle(pos,ss->ply))
@@ -905,7 +905,7 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
 
     // If position is a draw return a draw score
     if (MaterialDraw(pos))
-        return 0;
+        return (info->nodes & 2) - 1;
 
     // If we reached maxdepth we return a static evaluation of the position
     if (ss->ply >= MAXDEPTH - 1)

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-8.0.2"
+#define NAME "Alexandria-8.0.3"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
failed STC gainer bounds:
Elo   | -1.11 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | N: 24646 W: 5838 L: 5917 D: 12891
Penta | [62, 2861, 6566, 2762, 72]

passed LTC gainer bounds:
Elo   | 2.05 +- 1.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 41666 W: 9558 L: 9312 D: 22796
Penta | [26, 4522, 11481, 4788, 16]

