### PR TITLE
Qs stand pat failfirm

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -962,7 +962,7 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
 
     // Stand pat
     if (bestScore >= beta)
-        return bestScore;
+        return (bestScore + beta) / 2;
 
     // Adjust alpha based on eval
     alpha = std::max(alpha, bestScore);

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-8.0.3"
+#define NAME "Alexandria-8.0.4"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
I'm sure this scales at some point

Passed STC gainer bounds:
Elo   | 3.39 +- 2.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22856 W: 5395 L: 5172 D: 12289
Penta | [49, 2618, 5871, 2841, 49]

Dead neutral at LTC:
Elo   | 0.03 +- 2.21 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -0.78 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21922 W: 4824 L: 4822 D: 12276
Penta | [7, 2506, 5930, 2514, 4]

Bench: 6623357