### PR TITLE
Remove depth guard from nmp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -531,7 +531,6 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             && eval >= beta
             && ss->staticEval >= beta - 30 * depth + 170
             && (ss - 1)->move != NOMOVE
-            && depth >= 3
             && ss->ply >= td->nmpPlies
             && BoardHasNonPawns(pos, pos->side)) {
 


### PR DESCRIPTION
Elo   | 0.96 +- 1.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.0668 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 31896 W: 7352 L: 7264 D: 17280
Penta | [73, 3717, 8277, 3811, 70]

Elo   | 1.41 +- 2.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.2660 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 25118 W: 5715 L: 5613 D: 13790
Penta | [10, 2833, 6769, 2939, 8]

Bench: 6417573