### PR TITLE
Adjust out of scale Capthist malus multiplier

### DIFF
--- a/src/tune.h
+++ b/src/tune.h
@@ -152,7 +152,7 @@ TUNE_PARAM(historyMalusMax, 865, 1, 4096, 256, 0.002)
 TUNE_PARAM(capthistoryBonusMul, 336, 1, 1500, 32, 0.002)
 TUNE_PARAM(capthistoryBonusOffset, -89, -1024, 1024, 64, 0.002)
 TUNE_PARAM(capthistoryBonusMax, 2071, 1, 4096, 256, 0.002)
-TUNE_PARAM(capthistoryMalusMul, 3333, 1, 1500, 32, 0.002)
+TUNE_PARAM(capthistoryMalusMul, 333, 1, 1500, 32, 0.002)
 TUNE_PARAM(capthistoryMalusOffset, -84, -1024, 1024, 64, 0.002)
 TUNE_PARAM(capthistoryMalusMax, 1553, 1, 4096, 256, 0.002)
 // Conthist


### PR DESCRIPTION
Elo   | 2.71 +- 2.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 13850 W: 3299 L: 3191 D: 7360
Penta | [36, 1596, 3569, 1672, 52]

Bench: 6809244