### PR TITLE
Avoid copying back the position during UnmakeMove in favour of popping the stack

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -168,9 +168,9 @@ void updateCorrHistScore(const Position *pos, SearchData *sd, const SearchStack*
     const int newWeight = std::min(depth * depth + 2 * depth + 1, 128);
     assert(newWeight <= CORRHIST_WEIGHT_SCALE);
 
-    updateSingleCorrHistScore(sd->pawnCorrHist[pos->side][pos->state.pawnKey % CORRHIST_SIZE], scaledDiff, newWeight);
-    updateSingleCorrHistScore(sd->whiteNonPawnCorrHist[pos->side][pos->state.whiteNonPawnKey % CORRHIST_SIZE], scaledDiff, newWeight);
-    updateSingleCorrHistScore(sd->blackNonPawnCorrHist[pos->side][pos->state.blackNonPawnKey % CORRHIST_SIZE], scaledDiff, newWeight);
+    updateSingleCorrHistScore(sd->pawnCorrHist[pos->side][pos->state().pawnKey % CORRHIST_SIZE], scaledDiff, newWeight);
+    updateSingleCorrHistScore(sd->whiteNonPawnCorrHist[pos->side][pos->state().whiteNonPawnKey % CORRHIST_SIZE], scaledDiff, newWeight);
+    updateSingleCorrHistScore(sd->blackNonPawnCorrHist[pos->side][pos->state().blackNonPawnKey % CORRHIST_SIZE], scaledDiff, newWeight);
 
     if ((ss - 1)->move && (ss - 2)->move)
         updateSingleCorrHistScore(sd->contCorrHist[pos->side][PieceTypeTo((ss - 1)->move)][PieceTypeTo((ss - 2)->move)], scaledDiff, newWeight);
@@ -179,9 +179,9 @@ void updateCorrHistScore(const Position *pos, SearchData *sd, const SearchStack*
 int adjustEvalWithCorrHist(const Position *pos, const SearchData *sd, const SearchStack* ss, const int rawEval) {
     int adjustment = 0;
 
-    adjustment += sd->pawnCorrHist[pos->side][pos->state.pawnKey % CORRHIST_SIZE];
-    adjustment += sd->whiteNonPawnCorrHist[pos->side][pos->state.whiteNonPawnKey % CORRHIST_SIZE];
-    adjustment += sd->blackNonPawnCorrHist[pos->side][pos->state.blackNonPawnKey % CORRHIST_SIZE];
+    adjustment += sd->pawnCorrHist[pos->side][pos->state().pawnKey % CORRHIST_SIZE];
+    adjustment += sd->whiteNonPawnCorrHist[pos->side][pos->state().whiteNonPawnKey % CORRHIST_SIZE];
+    adjustment += sd->blackNonPawnCorrHist[pos->side][pos->state().blackNonPawnKey % CORRHIST_SIZE];
 
     if ((ss - 1)->move && (ss - 2)->move)
         adjustment += sd->contCorrHist[pos->side][PieceTypeTo((ss - 1)->move)][PieceTypeTo((ss - 2)->move)];

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -84,9 +84,9 @@ void PrintBoard(const Position* pos) {
            (pos->getCastlingPerm() & BKCA) ? 'k' : '-',
            (pos->getCastlingPerm() & BQCA) ? 'q' : '-');
 
-    std::cout << "position hisPly: " << pos->hisPly << std::endl;
+    std::cout << "position hisPly: " << pos->state().hisPly << std::endl;
 
-    std::cout << "position key: " << pos->posKey << std::endl;
+    std::cout << "position key: " << pos->getPoskey() << std::endl;
 
     std::cout << "pawn key: " << pos->state().pawnKey << std::endl;
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -88,7 +88,7 @@ void PrintBoard(const Position* pos) {
 
     std::cout << "position key: " << pos->posKey << std::endl;
 
-    std::cout << "pawn key: " << pos->state.pawnKey << std::endl;
+    std::cout << "pawn key: " << pos->state().pawnKey << std::endl;
 
     std::cout << "Fen: " << GetFen(pos) << "\n\n";
 }

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -244,7 +244,9 @@ bool shouldFlip(int from, int to) {
 // make move on chess board
 template <bool UPDATE>
 void MakeMove(const Move move, Position* pos) {
-    pos->history.push(pos->state());
+    if constexpr (UPDATE) {
+        pos->history.push(pos->state());
+    }
 
     // Store position key in the array of searched position
     pos->played_positions.emplace_back(pos->getPoskey());
@@ -290,7 +292,7 @@ void MakeMove(const Move move, Position* pos) {
     UpdatePinsAndCheckers(pos);
 
     // Make sure a freshly generated zobrist key matches the one we are incrementally updating
-    assert(pos->posKey == GeneratePosKey(pos));
+    assert(pos->getPoskey() == GeneratePosKey(pos));
     assert(pos->state().pawnKey == GeneratePawnKey(pos));
 }
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -104,8 +104,8 @@ int NNUE::povActivateAffine(Position *pos, NNUE::FinnyTable* FinnyPointer,  cons
     size_t addCnt = 0, removeCnt = 0;
 
     for (int piece = WP; piece <= BK; piece++) {
-        Bitboard added = pos->state.bitboards[piece] & ~cachedEntry.occupancies[piece];
-        Bitboard removed = cachedEntry.occupancies[piece] & ~pos->state.bitboards[piece];
+        Bitboard added = pos->state().bitboards[piece] & ~cachedEntry.occupancies[piece];
+        Bitboard removed = cachedEntry.occupancies[piece] & ~pos->state().bitboards[piece];
         while (added) {
             int square = popLsb(added);
             add[addCnt++] = getIndex(piece, square, side, kingBucket, flip);
@@ -116,7 +116,7 @@ int NNUE::povActivateAffine(Position *pos, NNUE::FinnyTable* FinnyPointer,  cons
             remove[removeCnt++] = getIndex(piece, square, side, kingBucket, flip);
         }
 
-        cachedEntry.occupancies[piece] = pos->state.bitboards[piece];
+        cachedEntry.occupancies[piece] = pos->state().bitboards[piece];
     }
 
     #if defined(USE_SIMD)

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -193,10 +193,10 @@ void ParseFen(const std::string& command, Position* pos) {
     }
     // Read Hisply moves counter
     if (!HisPly.empty()) {
-        pos->hisPly = std::stoi(HisPly);
+        pos->state().hisPly = std::stoi(HisPly);
     }
     else {
-        pos->hisPly = 0;
+        pos->state().hisPly = 0;
     }
 
     for (int piece = WP; piece <= WK; piece++)
@@ -207,7 +207,7 @@ void ParseFen(const std::string& command, Position* pos) {
         // populate white occupancy bitboard
         pos->state().occupancies[BLACK] |= pos->state().bitboards[piece];
 
-    pos->posKey = GeneratePosKey(pos);
+    pos->state().posKey = GeneratePosKey(pos);
     pos->state().pawnKey = GeneratePawnKey(pos);
     pos->state().whiteNonPawnKey = GenerateNonPawnKey(pos, WHITE);
     pos->state().blackNonPawnKey = GenerateNonPawnKey(pos, BLACK);
@@ -281,7 +281,7 @@ std::string GetFen(const Position* pos) {
     // Parse fifty moves counter
     fifty_move = std::to_string(pos->get50MrCounter());
     // Parse Hisply moves counter
-    HisPly = std::to_string(pos->hisPly);
+    HisPly = std::to_string(pos->state().hisPly);
 
     return pos_string + " " + turn + " " + castle_perm + " " + ep_square + " " + fifty_move + " " + HisPly;
 }
@@ -484,7 +484,7 @@ bool hasGameCycle(Position* pos, int ply) {
     };
 
     const Bitboard occ = pos->Occupancy(BOTH);
-    const ZobristKey originalKey = pos->posKey;
+    const ZobristKey originalKey = pos->getPoskey();
     ZobristKey other = (originalKey ^ OldKey(1) ^ SideKey);
 
     for (int i = 3; i <= end; i += 2)

--- a/src/position.h
+++ b/src/position.h
@@ -72,7 +72,7 @@ public:
        return history.historyStack[history.head];
     }
 
-    [[nodiscard]] inline const BoardState state() const  {
+    [[nodiscard]] inline const BoardState& state() const  {
         return history.historyStack[history.head];
     }
 

--- a/src/position.h
+++ b/src/position.h
@@ -44,12 +44,13 @@ struct historyStack{
     int head = 0;
 
     inline void push(BoardState state) {
-        historyStack[head] = state;
         head++;
+        historyStack[head] = state;
     }
 
-    inline BoardState pop() {
-        return historyStack[--head];
+    inline void pop() {
+        assert(head > 0);
+        head--;
     }
 
 };
@@ -58,7 +59,6 @@ struct Position {
 public:
     int side = -1; // what side has to move
 
-    BoardState state;
     int hisPly = 0; // total number of halfmoves
     // unique  hashkey  that encodes a board position
     ZobristKey posKey = 0ULL;
@@ -68,17 +68,25 @@ public:
     // Stores the zobrist keys of all the positions played in the game + the current search instance, used for 3-fold
     std::vector<ZobristKey> played_positions = {};
 
+    [[nodiscard]] inline BoardState& state()  {
+       return history.historyStack[history.head];
+    }
+
+    [[nodiscard]] inline const BoardState state() const  {
+        return history.historyStack[history.head];
+    }
+
     [[nodiscard]] inline Bitboard Occupancy(const int occupancySide) const {
         assert(occupancySide >= WHITE && occupancySide <= BOTH);
         if (occupancySide == BOTH)
-            return state.occupancies[WHITE] | state.occupancies[BLACK];
+            return state().occupancies[WHITE] | state().occupancies[BLACK];
         else
-            return state.occupancies[occupancySide];
+            return state().occupancies[occupancySide];
     }
 
     // Retrieve a generic piece (useful when we don't know what type of piece we are dealing with
     [[nodiscard]] inline Bitboard GetPieceColorBB(const int piecetype, const int color) const {
-        return state.bitboards[piecetype + color * 6];
+        return state().bitboards[piecetype + color * 6];
     }
 
     [[nodiscard]] inline int PieceCount() const {
@@ -87,7 +95,7 @@ public:
 
     [[nodiscard]] inline int PieceOn(const int square) const {
         assert(square >= 0 && square <= 63);
-        return state.pieces[square];
+        return state().pieces[square];
     }
 
     [[nodiscard]] inline ZobristKey getPoskey() const {
@@ -95,27 +103,27 @@ public:
     }
 
     [[nodiscard]] inline int get50MrCounter() const {
-        return state.fiftyMove;
+        return state().fiftyMove;
     }
 
     [[nodiscard]] inline int getCastlingPerm() const {
-        return state.castlePerm;
+        return state().castlePerm;
     }
 
     [[nodiscard]] inline int getEpSquare() const {
-        return state.enPas;
+        return state().enPas;
     }
 
     [[nodiscard]] inline int getPlyFromNull() const {
-        return state.plyFromNull;
+        return state().plyFromNull;
     }
 
     [[nodiscard]] inline Bitboard getCheckers() const {
-        return state.checkers;
+        return state().checkers;
     }
 
     [[nodiscard]] inline Bitboard getPinnedMask(int color) const {
-        return state.pinned[color];
+        return state().pinned[color];
     }
 
     inline void ChangeSide() {

--- a/src/position.h
+++ b/src/position.h
@@ -36,8 +36,9 @@ struct BoardState {
     ZobristKey pawnKey = 0ULL;
     ZobristKey whiteNonPawnKey = 0ULL;
     ZobristKey blackNonPawnKey = 0ULL;
-}; // stores a move and the state of the game before that move is made
-// for rollback purposes
+    ZobristKey posKey = 0ULL;
+    int hisPly = 0;
+};
 
 struct historyStack{
     BoardState    historyStack[MAXPLY];
@@ -58,11 +59,6 @@ struct historyStack{
 struct Position {
 public:
     int side = -1; // what side has to move
-
-    int hisPly = 0; // total number of halfmoves
-    // unique  hashkey  that encodes a board position
-    ZobristKey posKey = 0ULL;
-
     // stores the state of the board  rollback purposes
     historyStack history;
     // Stores the zobrist keys of all the positions played in the game + the current search instance, used for 3-fold
@@ -99,7 +95,7 @@ public:
     }
 
     [[nodiscard]] inline ZobristKey getPoskey() const {
-        return posKey;
+        return state().posKey;
     }
 
     [[nodiscard]] inline int get50MrCounter() const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -29,7 +29,7 @@ static bool IsRepetition(const Position* pos) {
     // Scan backwards from the first position where a repetition is possible (4 half moves ago) for at most distance steps
     for (int index = 4; index <= distance; index += 2)
         // if we found the same position hashkey as the current position
-        if (pos->played_positions[startingPoint - index] == pos->posKey) {
+        if (pos->played_positions[startingPoint - index] == pos->getPoskey()) {
 
             // we found a 2-fold repetition within the search tree
             if (index < pos->history.head)
@@ -492,7 +492,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         rawEval = EvalPosition(pos, &td->FTable);
         eval = ss->staticEval = adjustEvalWithCorrHist(pos, sd, ss, rawEval);
         // Save the eval into the TT
-        StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, rawEval, HFNONE, 0, pvNode, ttPv);
+        StoreTTEntry(pos->getPoskey(), NOMOVE, SCORE_NONE, rawEval, HFNONE, 0, pvNode, ttPv);
     }
 
     // Use static evaluation difference to improve quiet move ordering (~6 Elo)
@@ -622,7 +622,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             UnmakeMove(pos);
 
             if (pcScore >= pcBeta) {
-                StoreTTEntry(pos->posKey, MoveToTT(move),
+                StoreTTEntry(pos->getPoskey(), MoveToTT(move),
                              ScoreToTT(pcScore, ss->ply), rawEval, HFLOWER,
                              depth - 3, pvNode, ttPv);
                 return pcScore;
@@ -886,7 +886,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             &&  !(bound == HFUPPER && bestScore >= ss->staticEval)) {
             updateCorrHistScore(pos, sd, ss, depth, bestScore - ss->staticEval);
         }
-        StoreTTEntry(pos->posKey, MoveToTT(bestMove), ScoreToTT(bestScore, ss->ply), rawEval, bound, depth, pvNode, ttPv);
+        StoreTTEntry(pos->getPoskey(), MoveToTT(bestMove), ScoreToTT(bestScore, ss->ply), rawEval, bound, depth, pvNode, ttPv);
     }
 
     return bestScore;
@@ -965,7 +965,7 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
         rawEval = EvalPosition(pos, &td->FTable);
         bestScore = ss->staticEval = adjustEvalWithCorrHist(pos, sd, ss, rawEval);
         // Save the eval into the TT
-        StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, rawEval, HFNONE, 0, pvNode, ttPv);
+        StoreTTEntry(pos->getPoskey(), NOMOVE, SCORE_NONE, rawEval, HFNONE, 0, pvNode, ttPv);
     }
 
     // Stand pat
@@ -1042,7 +1042,7 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
     // Set the TT bound based on whether we failed high, for qsearch we never use the exact bound
     int bound = bestScore >= beta ? HFLOWER : HFUPPER;
 
-    StoreTTEntry(pos->posKey, MoveToTT(bestmove), ScoreToTT(bestScore, ss->ply), rawEval, bound, 0, pvNode, ttPv);
+    StoreTTEntry(pos->getPoskey(), MoveToTT(bestmove), ScoreToTT(bestScore, ss->ply), rawEval, bound, 0, pvNode, ttPv);
 
     return bestScore;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -20,7 +20,7 @@
 
 // Returns true if the position is a 2-fold repetition, false otherwise
 static bool IsRepetition(const Position* pos) {
-    assert(pos->hisPly >= pos->get50MrCounter());
+    assert(pos->state().hisPly >= pos->get50MrCounter());
     int counter = 0;
     // How many moves back should we look at most, aka our distance to the last irreversible move
     int distance = std::min(pos->get50MrCounter(), pos->getPlyFromNull());


### PR DESCRIPTION
Cleaner code, strictly faster computation wise.

Elo   | 1.09 +- 1.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.48 (-2.25, 2.89) [0.00, 3.00]
Games | N: 76708 W: 17809 L: 17568 D: 41331
Penta | [151, 8093, 21630, 8324, 156]

Bench: 6809244