### PR TITLE
Partially prevent graph history interaction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -454,6 +454,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
     if (   !pvNode
         &&  ttScore != SCORE_NONE
         &&  ttDepth >= depth
+        && pos->get50MrCounter() > 90
         && (   (ttBound == HFUPPER && ttScore <= alpha)
             || (ttBound == HFLOWER && ttScore >= beta)
             ||  ttBound == HFEXACT))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -454,7 +454,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
     if (   !pvNode
         &&  ttScore != SCORE_NONE
         &&  ttDepth >= depth
-        && pos->get50MrCounter() > 90
+        && pos->get50MrCounter() < 90
         && (   (ttBound == HFUPPER && ttScore <= alpha)
             || (ttBound == HFLOWER && ttScore >= beta)
             ||  ttBound == HFEXACT))


### PR DESCRIPTION
Very bad at STC:
Elo   | -4.15 +- 3.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8876 W: 1951 L: 2057 D: 4868
Penta | [13, 986, 2544, 884, 11]

Neutral at LTC:
Elo   | -0.10 +- 1.36 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -2.03 (-2.25, 2.89) [0.00, 3.00]
Games | N: 46912 W: 10253 L: 10267 D: 26392
Penta | [15, 4343, 14748, 4341, 9]

Neutral enough at 60s:
Elo   | -0.81 +- 1.97 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | -1.82 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21426 W: 4662 L: 4712 D: 12052
Penta | [6, 1926, 6896, 1882, 3]

