### PR TITLE
Relax the fail depth reduction limit

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -334,7 +334,6 @@ int AspirationWindowSearch(int prev_eval, int depth, ThreadData* td) {
     // define initial alpha beta bounds
     int alpha = -MAXSCORE;
     int beta = MAXSCORE;
-    int failhighCount = 0;
 
     // only set up the windows is the search depth is bigger or equal than Aspiration_Depth to avoid using windows when the search isn't accurate enough
     if (depth >= 3) {
@@ -361,14 +360,12 @@ int AspirationWindowSearch(int prev_eval, int depth, ThreadData* td) {
             beta = (alpha + beta) / 2;
             alpha = std::max(-MAXSCORE, score - delta);
             depth = td->RootDepth;
-            failhighCount = 0;
         }
 
         // We fell outside the window, so try again with a bigger window
         else if (score >= beta) {
             beta = std::min(score + delta, MAXSCORE);
-            failhighCount += 1;
-            depth = std::max(td->RootDepth - failhighCount, 1);
+            depth = std::max(depth - 1, 1);
         }
         else
             break;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -334,6 +334,7 @@ int AspirationWindowSearch(int prev_eval, int depth, ThreadData* td) {
     // define initial alpha beta bounds
     int alpha = -MAXSCORE;
     int beta = MAXSCORE;
+    int failhighCount = 0;
 
     // only set up the windows is the search depth is bigger or equal than Aspiration_Depth to avoid using windows when the search isn't accurate enough
     if (depth >= 3) {
@@ -360,12 +361,14 @@ int AspirationWindowSearch(int prev_eval, int depth, ThreadData* td) {
             beta = (alpha + beta) / 2;
             alpha = std::max(-MAXSCORE, score - delta);
             depth = td->RootDepth;
+            failhighCount = 0;
         }
 
         // We fell outside the window, so try again with a bigger window
         else if (score >= beta) {
             beta = std::min(score + delta, MAXSCORE);
-            depth = std::max(depth - 1, td->RootDepth - 5);
+            failhighCount += 1;
+            depth = std::max(td->RootDepth - failhighCount, 1);
         }
         else
             break;


### PR DESCRIPTION
Elo   | 0.69 +- 1.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.14 (-2.25, 2.89) [0.00, 3.00]
Games | N: 99362 W: 23474 L: 23277 D: 52611
Penta | [187, 10471, 28179, 10646, 198]

Elo   | 2.91 +- 1.96 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21964 W: 5019 L: 4835 D: 12110
Penta | [4, 1890, 7011, 2072, 5]

Bench: 6738798