### PR TITLE
Use keyAfter for nmp

### DIFF
--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -274,7 +274,6 @@ void MakeMove(const Move move, Position* pos) {
         MakeCapture(move, pos);
     }
 
-    // change side
     pos->ChangeSide();
     // Xor the new side into the key
     HashKey(pos->state().posKey, SideKey);

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -297,11 +297,9 @@ void MakeNullMove(Position* pos) {
     pos->history.push(pos->state());
     // Store position key in the array of searched position
     pos->played_positions.emplace_back(pos->getPoskey());
-    // Update the zobrist key asap so we can prefetch
     resetEpSquare(pos);
     pos->ChangeSide();
     HashKey(pos->state().posKey, SideKey);
-    TTPrefetch(pos->getPoskey());
 
     pos->state().hisPly++;
     pos->state().fiftyMove++;

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -304,8 +304,9 @@ void MakeNullMove(Position* pos) {
     pos->state().fiftyMove++;
     pos->state().plyFromNull = 0;
 
-    // Update pinmasks and checkers
-    UpdatePinsAndCheckers(pos);
+    // we haven't moved any piece, so pins stay unchanged, as far as checkers for the opponent's side:
+    // if the opponent was in check before we could play this move we would've won, so they weren't
+    // that can't change after a nullmove, therefore do not update pins and checkers
 }
 
 // Take back a null move

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -457,6 +457,11 @@ Bitboard RayBetween(int square1, int square2) {
 // Calculates what the key for position pos will be after move <move>, it's a rough estimate and will fail for "special" moves such as promotions and castling
 ZobristKey keyAfter(const Position* pos, const Move move) {
 
+    if(move == NOMOVE){
+        ZobristKey newKey = pos->getPoskey() ^ SideKey;
+        return newKey;
+    }
+
     const int sourceSquare = From(move);
     const int targetSquare = To(move);
     const int piece = Piece(move);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -548,6 +548,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
             const int R = 4 + depth / 3 + std::min((eval - beta) / nmpReductionEvalDivisor(), 3);
             ss->contHistEntry = &sd->contHist[PieceTo(NOMOVE)];
 
+            TTPrefetch(keyAfter(pos, NOMOVE));
             MakeNullMove(pos);
 
             // Search moves at a reduced depth to find beta cutoffs.


### PR DESCRIPTION
Elo   | 0.39 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.63 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 27026 W: 6271 L: 6241 D: 14514
Penta | [48, 2770, 7842, 2810, 43]

Cosmo said it was good enough

Bench: 6738798