### PR TITLE
Improve minimal uci output

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -304,7 +304,7 @@ void SearchPosition(int startDepth, int finalDepth, ThreadData* td, UciOptions* 
             break;
 
         // If it's the main thread print the uci output
-        if (td->id == 0 && !shortUCI)
+        if (td->id == 0 && (!shortUCI || currentDepth == finalDepth))
             PrintUciOutput(score, currentDepth, td, options);
 
         // Seldepth should only be related to the current ID loop


### PR DESCRIPTION
Add a small tweak to guarantee an output in case the search reaches max depth instead of getting stopped.
Covers both "go depth" commands and situations where the engine gets to maxdepth thanks to MDP.

Bench: 8744718