### PR TITLE
Simplify history update

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -110,7 +110,6 @@ void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const
         for (int i = 0; i < quietMoves->count; i++) {
             // For all the quiets moves that didn't cause a cut-off decrease the HH score
             const Move move = quietMoves->moves[i];
-            if (move == bestMove) continue;
             updateHHScore(pos, sd, move, -malus);
             updateCHScore(ss, move, -conthist_malus);
             if (rootNode)
@@ -124,7 +123,6 @@ void UpdateHistories(const Position* pos, SearchData* sd, SearchStack* ss, const
     // For all the noisy moves that didn't cause a cut-off, even is the bestMove wasn't a noisy move, decrease the capthist score
     for (int i = 0; i < noisyMoves->count; i++) {
         const Move move = noisyMoves->moves[i];
-        if (move == bestMove) continue;
         updateCapthistScore(pos, sd, move, -capthist_malus);
     }
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -52,7 +52,7 @@ static bool Is50MrDraw(Position* pos) {
         if (!pos->getCheckers())
             return true;
 
-        // if we are in check make sure it's not checkmate 
+        // if we are in check make sure it's not checkmate
         MoveList moveList;
         // generate moves
         GenerateMoves(&moveList, pos, MOVEGEN_ALL);
@@ -85,7 +85,7 @@ void ClearForSearch(ThreadData* td) {
     info->starttime = GetTimeMs();
     info->nodes = 0;
     info->seldepth = 0;
-    
+
     // Main thread clears pvTable, nodeSpentTable, and unpauses any eventual search thread
     if (td->id == 0) {
         // Clean the Pv array
@@ -750,11 +750,6 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
         // Play the move
         MakeMove<true>(move, pos);
         ss->contHistEntry = &sd->contHist[PieceTo(move)];
-        // Add any played move to the matching list
-        if(isQuiet)
-            quietMoves.addMove(move);
-        else
-            noisyMoves.addMove(move);
 
         // increment nodes count
         info->nodes++;
@@ -819,7 +814,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
 
             // if we failed high on a reduced node we'll search with a reduced window and full depth
             if (score > alpha && newDepth > reducedDepth) {
-                // Based on the value returned by our reduced search see if we should search deeper or shallower, 
+                // Based on the value returned by our reduced search see if we should search deeper or shallower,
                 // this is an exact yoink of what SF does and frankly i don't care lmao
                 const bool doDeeperSearch = score > (bestScore + doDeeperBaseMargin() + 2 * newDepth);
                 const bool doShallowerSearch = score < (bestScore + newDepth);
@@ -886,6 +881,11 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
                 alpha = score;
             }
         }
+        // Add any searched move to the matching list
+        if (isQuiet)
+            quietMoves.addMove(move);
+        else
+            noisyMoves.addMove(move);
     }
 
     // We don't have any legal moves to make in the current postion. If we are in singular search, return -infinite.


### PR DESCRIPTION
Changing quietMoves/noisyMoves to only contain fully searched moves let's us not having to handle duplicated bestmoves during history updates.

Bench: 9100977