### PR TITLE
Fix partial fen handling

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -27,6 +27,16 @@ inline long long int _count, _accumulator;
     return tokens;
 }
 
+inline std::string getPosition (std::string command) {
+    // parse only up to the "moves" token (if present) to handle partial fens without the 50mr counter and the fullmove counter
+    size_t start = command.find("fen") + 4;
+    size_t end = command.find("moves");
+    // avoid doing a subtraction with npos
+    if (end == std::string::npos)
+        return command.substr(start);
+    return command.substr(start, end - start);
+}
+
 // returns true if in a vector of string there's one that matches the key
 [[nodiscard]] inline bool Contains(const std::vector<std::string>& tokens, const std::string& key) {
     return std::find(tokens.begin(), tokens.end(), key) != tokens.end();

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -194,7 +194,7 @@ void ParseFen(const std::string& command, Position* pos) {
         pos->state().hisPly = std::stoi(HisPly);
     }
     else {
-        pos->state().hisPly = 0;
+        pos->state().hisPly = 1;
     }
 
     for (int piece = WP; piece <= WK; piece++)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -80,8 +80,9 @@ void ParsePosition(const std::string& command, Position* pos) {
     else {
         // if a "fen" command is available within command string
         if (command.find("fen") != std::string::npos) {
-            // init chess board with position from FEN string
-            ParseFen(command.substr(command.find("fen") + 4, std::string::npos), pos);
+            // Substring from after "fen" up to "moves"
+            std::string position = getPosition(command);
+            ParseFen(position, pos);
         }
         else {
             // init chess board with start position


### PR DESCRIPTION
fixes an issue where fens without the 50mr and fullmove counter (but a "moves" token) would lead to a stoi exception.
Example fen: `position fen 5rk1/2p4p/2p4r/3P4/4p1b1/1Q2NqPp/PP3P1K/R4R2 b - - moves`.
closes #566. 
Bench: 9118561
