### PR TITLE
Enforce Qsearch fail mid consistency

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1074,6 +1074,10 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
     if (totalMoves == 0 && inCheck) {
         return -MATE_SCORE + ss->ply;
     }
+
+    if (bestScore >= beta && !isDecisive(bestScore) && !isDecisive(beta))
+        bestScore = (bestScore + beta) / 2;
+
     // Set the TT bound based on whether we failed high, for qsearch we never use the exact bound
     int bound = bestScore >= beta ? HFLOWER : HFUPPER;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -999,7 +999,7 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
         }
 
         // Stand pat
-        if (bestScore >= beta) {
+        if (bestScore >= beta &&!isDecisive(beta) && !isDecisive(bestScore)) {
             return (bestScore + beta) / 2;
         }
 


### PR DESCRIPTION
Elo   | 0.55 +- 1.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 42436 W: 10227 L: 10160 D: 22049
Penta | [113, 5032, 10850, 5121, 102]

Bench: 8600154