### PR TITLE
Don't return decisive scores from singular search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -744,7 +744,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
                         depth += depth < 10;
                     }
                 }
-                else if (singularScore >= beta)
+                else if (singularScore >= beta && !isDecisive(singularScore))
                     return singularScore;
 
                 // If we didn't successfully extend and our TT score is above beta reduce the search depth


### PR DESCRIPTION
Elo   | -0.04 +- 1.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.09 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 35808 W: 8478 L: 8482 D: 18848
Penta | [61, 4127, 9527, 4133, 56]