### PR TITLE
Allow triple extension of tactical moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -740,7 +740,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
 
                     if (   !pvNode
                         &&  singularScore < singularBeta - 10) {
-                        extension = 2 + (!isTactical(ttMove) && singularScore < singularBeta - 75);
+                        extension = 2 + singularScore < singularBeta - 75;
                         depth += depth < 10;
                     }
                 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -740,7 +740,7 @@ int Negamax(int alpha, int beta, int depth, const bool cutNode, ThreadData* td, 
 
                     if (   !pvNode
                         &&  singularScore < singularBeta - 10) {
-                        extension = 2 + singularScore < singularBeta - 75;
+                        extension = 2 + (singularScore < singularBeta - 75);
                         depth += depth < 10;
                     }
                 }


### PR DESCRIPTION
Possibly quite bad at STC:
Elo   | -3.42 +- 3.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.55 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 8232 W: 1934 L: 2015 D: 4283
Penta | [21, 1032, 2088, 957, 18]

Neutral (at least) at LTC:
Elo   | 1.63 +- 2.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 20244 W: 4735 L: 4640 D: 10869
Penta | [11, 2281, 5441, 2380, 9]

Bench: 8823740