### PR TITLE
Remove bad capture movelist from movepicker

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -50,6 +50,7 @@ void InitMP(Movepicker* mp, Position* pos, SearchData* sd, SearchStack* ss, cons
     mp->ss = ss;
     mp->ttMove = ttMove;
     mp->idx = 0;
+    mp->badcapturesCount = 0;
     mp->rootNode = rootNode;
     mp->stage = mp->ttMove ? PICK_TT : GEN_NOISY;
     mp->killer = killer != ttMove ? killer : NOMOVE;
@@ -114,7 +115,8 @@ Move NextMove(Movepicker* mp, const bool skip) {
                 continue;
 
             if (!SEE(mp->pos, move, SEEThreshold)) {
-                AddMove(move, score, &mp->badCaptureList);
+                // since these moves are already sorted we can ditch the score, it won't be checked again
+                mp->moveList.moves[mp->badcapturesCount++].move = move;
                 continue;
             }
 
@@ -166,8 +168,8 @@ Move NextMove(Movepicker* mp, const bool skip) {
         goto top;
 
     case PICK_BAD_NOISY:
-        while (mp->idx < mp->badCaptureList.count) {
-            const Move move = mp->badCaptureList.moves[mp->idx].move;
+        while (mp->idx < mp->badcapturesCount) {
+            const Move move = mp->moveList.moves[mp->idx].move;
             ++mp->idx;
             if (move == mp->ttMove)
                 continue;

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -28,7 +28,7 @@ struct Movepicker {
     SearchData* sd;
     SearchStack* ss;
     MoveList moveList;
-    MoveList badCaptureList;
+    int badcapturesCount;
     Move ttMove;
     Move killer;
     Move counter;

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-8.1.7"
+#define NAME "Alexandria-8.1.8"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION
Elo   | 2.04 +- 2.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 16024 W: 3835 L: 3741 D: 8448
Penta | [22, 1472, 4935, 1556, 27]

Bench: 8823740