### PR TITLE
Introduce score stability TM scaling

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -255,6 +255,8 @@ void SearchPosition(int startDepth, int finalDepth, ThreadData* td, UciOptions* 
     int score = 0;
     int prevScore = 0;
     int averageScore = SCORE_NONE;
+    int prevIdScore = SCORE_NONE;
+    bool completedDepth = false;
     int bestMoveStabilityFactor = 0;
     int evalStabilityFactor = 0;
     Move previousBestMove = NOMOVE;
@@ -294,7 +296,7 @@ void SearchPosition(int startDepth, int finalDepth, ThreadData* td, UciOptions* 
             // use the previous search to adjust some of the time management parameters, do not scale movetime time controls
             if (   td->RootDepth > 7
                 && td->info.timeset) {
-                ScaleTm(td, bestMoveStabilityFactor, evalStabilityFactor);
+                ScaleTm(td, bestMoveStabilityFactor, evalStabilityFactor, score, prevIdScore, td->lastSearchScore);
             }
 
             // check if we just cleared a depth and more than OptTime passed, or we used more than the give nodes
@@ -321,7 +323,13 @@ void SearchPosition(int startDepth, int finalDepth, ThreadData* td, UciOptions* 
         // Seldepth should only be related to the current ID loop
         td->info.seldepth = 0;
         prevScore = score;
+        prevIdScore = score;
+        completedDepth = true;
     }
+
+    // Keep last completed search score for score-loss TM scaling in the next move
+    if (td->id == 0 && completedDepth)
+        td->lastSearchScore = prevScore;
 }
 
 int AspirationWindowSearch(int prev_eval, int depth, ThreadData* td) {

--- a/src/threads.h
+++ b/src/threads.h
@@ -80,6 +80,7 @@ struct ThreadData {
     std::vector<ZobristKey> keyHistory;
     int RootDepth;
     int nmpPlies;
+    int lastSearchScore = SCORE_NONE;
 
     NNUE::FinnyTable FTable{};
 

--- a/src/time_manager.cpp
+++ b/src/time_manager.cpp
@@ -40,7 +40,8 @@ bool StopEarly(const SearchInfo* info) {
     return (info->timeset || info->movetimeset) && GetTimeMs() > info->stoptimeOpt;
 }
 
-void ScaleTm(ThreadData* td, const int bestMoveStabilityFactor, const int evalStabilityFactor) {
+void ScaleTm(ThreadData* td, const int bestMoveStabilityFactor, const int evalStabilityFactor,
+             const int currentScore, const int prevIdScore, const int prevSearchScore) {
     const double bestmoveScale[5] = {bmScale1() / 100.0, bmScale2() / 100.0, bmScale3() / 100.0, bmScale4() / 100.0, bmScale5() / 100.0};
     const double evalScale[5] = {evalScale1() / 100.0, evalScale2() / 100.0, evalScale3() / 100.0, evalScale4() / 100.0, evalScale5() / 100.0};
     const int bestmove = GetBestMove();
@@ -49,8 +50,15 @@ void ScaleTm(ThreadData* td, const int bestMoveStabilityFactor, const int evalSt
     const double nodeScalingFactor = (nodeTmBase() / 100.0 - bestMoveNodesFraction) * (nodeTmMultiplier() / 100.0);
     const double bestMoveScalingFactor = bestmoveScale[bestMoveStabilityFactor];
     const double evalScalingFactor = evalScale[evalStabilityFactor];
+    const int idScoreDrop = prevIdScore == SCORE_NONE ? 0 : (prevIdScore - currentScore);
+    const int searchScoreDrop = prevSearchScore == SCORE_NONE ? 0 : (prevSearchScore - currentScore);
+    const double scoreLoss = scoreTmBase() / 100.0
+        + scoreTmIDPrev() / 1000.0 * idScoreDrop
+        + scoreTmPrevSearch() / 1000.0 * searchScoreDrop;
+    const double scoreScalingFactor = std::clamp(scoreLoss, scoreTmClampMin() / 100.0, scoreTmClampMax() / 100.0);
     // Scale the search time based on how many nodes we spent and how the best move changed
-    td->info.stoptimeOpt = std::min<uint64_t>(td->info.starttime + td->info.stoptimeBaseOpt * nodeScalingFactor * bestMoveScalingFactor * evalScalingFactor, td->info.stoptimeMax);
+    td->info.stoptimeOpt = std::min<uint64_t>(td->info.starttime + td->info.stoptimeBaseOpt * nodeScalingFactor
+        * bestMoveScalingFactor * evalScalingFactor * scoreScalingFactor, td->info.stoptimeMax);
 
 }
 

--- a/src/time_manager.h
+++ b/src/time_manager.h
@@ -7,4 +7,5 @@ void Optimum(SearchInfo* info, int time, int inc);
 [[nodiscard]] bool StopEarly(const SearchInfo* info);
 [[nodiscard]] bool TimeOver(const SearchInfo* info);
 [[nodiscard]] bool NodesOver(const SearchInfo* info);
-void ScaleTm(ThreadData* td, const int bestMoveStabilityFactor, const int evalStabilityFactor);
+void ScaleTm(ThreadData* td, const int bestMoveStabilityFactor, const int evalStabilityFactor,
+			 const int currentScore, const int prevIdScore, const int prevSearchScore);

--- a/src/tune.h
+++ b/src/tune.h
@@ -126,6 +126,13 @@ TUNE_TM_PARAM(evalScale5, 87, 40, 110, 4, 0.002)
 TUNE_TM_PARAM(nodeTmBase, 153, 100, 300, 10, 0.002)
 TUNE_TM_PARAM(nodeTmMultiplier, 174, 80, 250, 8, 0.002)
 
+// Score-loss TM scaling
+TUNE_TM_PARAM(scoreTmBase, 86, 0, 150, 8, 0.002)
+TUNE_TM_PARAM(scoreTmIDPrev, 10, 0, 20, 2, 0.002)
+TUNE_TM_PARAM(scoreTmPrevSearch, 25, 0, 50, 3, 0.002)
+TUNE_TM_PARAM(scoreTmClampMin, 81, 0, 150, 6, 0.002)
+TUNE_TM_PARAM(scoreTmClampMax, 150, 75, 225, 8, 0.002)
+
 // Search
 TUNE_PARAM(aspWinDelta, 8, 2, 15, 2, 0.002)
 TUNE_PARAM(aspWinPrevevalDiv, 18666, 12000, 25000, 512, 0.002)

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,7 @@
 // include the tune stuff here to give it global visibility
 #include "tune.h"
 
-#define NAME "Alexandria-9.0.10"
+#define NAME "Alexandria-9.0.11"
 
 inline int reductions[2][64][64];
 inline int lmp_margin[64][2];


### PR DESCRIPTION

Elo   | 4.24 +- 2.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16560 W: 4147 L: 3945 D: 8468
Penta | [28, 1830, 4365, 2026, 31]
https://chess.swehosting.se/test/14309/

Elo   | 4.00 +- 2.49 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16844 W: 4230 L: 4036 D: 8578
Penta | [5, 1777, 4662, 1975, 3]
https://chess.swehosting.se/test/14310/

Bench: 7823705

